### PR TITLE
Bugfix/mysqldef duplicate targets

### DIFF
--- a/trunk/src/lsc/mysqldef.py
+++ b/trunk/src/lsc/mysqldef.py
@@ -436,19 +436,28 @@ def targimg(img='', hdrt=None):
     ########  define targetid  ##################
     _targetid=lsc.mysqldef.gettargetid(_object,'','',conn,.01,False)
     if not _targetid:
-       print '# no target with this name '+_object
-       _targetid=lsc.mysqldef.gettargetid('',_ra,_dec,conn,.01,False)
-       if _targetid:
-          print '# target at this coordinate with a different name, add name '+str(_ra)+' '+str(_dec)
-          dictionary1={'name':_object,'targetid':_targetid,'groupidcode':_group}
-          lsc.mysqldef.insert_values(conn,'targetnames',dictionary1)
+        print '# no target with this name '+_object
+        _targetid=lsc.mysqldef.gettargetid('',_ra,_dec,conn,.01,False)
+        if _targetid:
+            print '# target at this coordinate with a different name, add name '+str(_ra)+' '+str(_dec)
+            dictionary1={'name':_object,'targetid':_targetid,'groupidcode':_group}
+            lsc.mysqldef.insert_values(conn,'targetnames',dictionary1)
 
-          bb2=lsc.mysqldef.query(['select id from targetnames where name = "'+_object+'"'],conn)
-          dictionary3 = {'userid':67, 'tablemodified': 'targetnames', 'idmodified': bb2[0]['id'],
-                         'columnmodified': 'New Row', 'newvalue': 'Multiple'}
-          lsc.mysqldef.insert_values(conn,'useractionlog',dictionary3)
-       else:
-           print 'not found targetid with ra and dec '+str(_ra)+' '+str(_dec)
+            bb2=lsc.mysqldef.query(['select id from targetnames where name = "'+_object+'"'],conn)
+            dictionary3 = {'userid':67, 'tablemodified': 'targetnames', 'idmodified': bb2[0]['id'],
+                          'columnmodified': 'New Row', 'newvalue': 'Multiple'}
+            lsc.mysqldef.insert_values(conn,'useractionlog',dictionary3)
+        else:
+            print '# try to find target at ofst RA and dec'
+            if ('OFST-RA' in hdrt and 'OFST-DEC' in hdrt and 
+                hdrt['OFST-RA'] not in lsc.util.missingvalues and hdrt['OFST-DEC'] not in lsc.util.missingvalues):
+                _ofst_ra = lsc.util.readkey3(hdrt, 'OFST-RA')
+                _ofst_dec = lsc.util.readkey3(hdrt, 'OFST-DEC')
+                _targetid = lsc.mysqldef.gettargetid('',_ofst_ra,_ofst_dec,conn,.01,False)
+
+                if not _targetid:
+                    print 'not found targetid with ra and dec '+str(_ra)+' '+str(_dec)
+
     else:
         print 'found name= '+_object+'  targetid= '+str(_targetid)
     ##############################################

--- a/trunk/src/lsc/mysqldef.py
+++ b/trunk/src/lsc/mysqldef.py
@@ -407,12 +407,11 @@ def targimg(img='', hdrt=None):
     if hdrt is None:
         hdrt=lsc.util.readhdr(img)
     
-    try:
-        _ra=lsc.util.readkey3(hdrt,'CAT-RA')
-        _dec=lsc.util.readkey3(hdrt,'CAT-DEC')
+    _ra=lsc.util.readkey3(hdrt,'CAT-RA')
+    _dec=lsc.util.readkey3(hdrt,'CAT-DEC')
 
-    except:
-        # No CAT RA and dec, so send a warning message to slack and return exception
+    if _ra is None or _dec is None:
+        # No CAT RA or dec, so send a warning message to slack and return exception
         # Send Slack message
         post_url = os.environ['SLACK_CHANNEL_WEBHOOK']
         payload = {'text': 'CAT-RA and CAT-DEC could not be found for {}'.format(img)}
@@ -421,7 +420,7 @@ def targimg(img='', hdrt=None):
         response = requests.post(post_url, data=json_data.encode('ascii'), headers=headers)
 
         # Raise exception so pipeline moves on to ingesting the next image
-        raise
+        raise Exception ('No CAT-RA or CAT-DEC could be found for {}'.format(img))
 
     _object=lsc.util.readkey3(hdrt,'object')
     if ':' in str(_ra):        


### PR DESCRIPTION
Changed `mysqldef.py` to only look for the CAT RA and CAT DEC in the headers of each image, rather than other coordinates, to avoid creating duplicate target entries if the telescope pointing is off. If CAT RA and CAT DEC aren't in the header it will raise an exception and send a slack message to the SBA supernova group. 