### PR TITLE
Improve iraf image handling

### DIFF
--- a/trunk/bin/lscmaketempl.py
+++ b/trunk/bin/lscmaketempl.py
@@ -119,8 +119,8 @@ if __name__ == "__main__":
                 if chosepos:
                     print 'choose xpos, ypos interactively'
                     lsc.util.delete('tmp.log')
-                    zz1, zz2, goon = lsc.util.display_image(img, 1, '', '', True)
-                    iraf.imexamine(img, 1, wcs='logical', logfile='tmp.log', keeplog=True)
+                    zz1, zz2, goon = lsc.util.display_image(img, 1, 0, 6000, True)
+                    iraf.imexamine(wcs='logical', logfile='tmp.log', keeplog=True)
                     xytargets = iraf.fields('tmp.log', '1,2', Stdout=1)
                     _xpos, _ypos = string.split(xytargets[0])[0], string.split(xytargets[0])[1]
                 elif not _ra or not _dec:
@@ -180,6 +180,7 @@ if __name__ == "__main__":
                 while answ == 'n':
                     coordlist = str(_xpos) + '   ' + str(_ypos) + '    ' + str(_mag)
                     os.system('echo ' + coordlist + ' > ddd')
+                    _z11, _z22, goon = lsc.util.display_image(img0, 1, z11, z22, False)
                     iraf.imarith(img0, '-', img0, '_tmp.fits', verbose='no')
                     if float(_mag) != 0.0:
                         iraf.daophot.addstar("_tmp.fits", 'ddd', psfimg, "_tmp2.fits", nstar=1, veri='no', simple='yes',

--- a/trunk/bin/lscmaketempl.py
+++ b/trunk/bin/lscmaketempl.py
@@ -65,6 +65,7 @@ if __name__ == "__main__":
     from pyraf import iraf
     from iraf import digiphot
     from iraf import daophot
+    iraf.set(stdimage='imt2048')
     from astropy.wcs import WCS
     ##################################
     goon = False

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -903,7 +903,7 @@ def checkpsf(imglist, database='photlco'):
 def checkwcs(imglist, force=True, database='photlco', _z1='', _z2=''):
     iraf.digiphot(_doprint=0)
     iraf.daophot(_doprint=0)
-    iraf.set(stdimage='imt1024')
+    iraf.set(stdimage='imt2048')
     print force
     print _z1, _z2
     for img in imglist:
@@ -1165,7 +1165,7 @@ def display_subtraction(img):
 def checkdiff(imglist, database='photlco'):
     iraf.digiphot(_doprint=0)
     iraf.daophot(_doprint=0)
-    iraf.set(stdimage='imt1024')
+    iraf.set(stdimage='imt2048')
     for img in imglist:
         status = checkstage(img, 'wcs')
         if status >= 0:
@@ -1276,7 +1276,7 @@ def checkpos(imglist, _ra, _dec, database='photlco'):
 def checkquality(imglist, database='photlco'):
     iraf.digiphot(_doprint=0)
     iraf.daophot(_doprint=0)
-    iraf.set(stdimage='imt1024')
+    iraf.set(stdimage='imt2048')
     for img in imglist:
         status = checkstage(img, 'checkquality')
         if status == -4:


### PR DESCRIPTION
This PR changes many `iraf.set(stdimage='imt1024')` -->` iraf.set(stdimage='imt2048')` and changes an imexamine call to explicitly specify z1 and z2 and removes the frame specification. @svalenti can elaborate on why this change was made.