### PR TITLE
adding the ability to ingest .fits.fz files 

### DIFF
--- a/trunk/src/lsc/mysqldef.py
+++ b/trunk/src/lsc/mysqldef.py
@@ -201,8 +201,18 @@ def ingestredu(imglist,force='no',dataredutable='photlco',filetype=1):
    conn = lsc.mysqldef.dbConnect(hostname, username, passwd, database)
 
    for fullpath in imglist:
+      print(fullpath)
       path, img = os.path.split(fullpath)
       path += '/'
+
+######  for external users ingesting directly in lcophot ######      
+      if img[-3:] == '.fz':
+         os.system('funpack -D ' + fullpath)
+         img = img[:-3]
+         fullpath = fullpath[:-3]
+         if os.path.isfile(fullpath + '.fz'):
+            os.remove(fullpath + '.fz')
+############################################################
 
       exist=lsc.mysqldef.getfromdataraw(conn,dataredutable,'filename', string.split(img,'/')[-1],column2='filename')
       exist2=lsc.mysqldef.getfromdataraw(conn,'photlcoraw','filename', string.split(img,'/')[-1],column2='filename, groupidcode')
@@ -220,8 +230,8 @@ def ingestredu(imglist,force='no',dataredutable='photlco',filetype=1):
             exist=lsc.mysqldef.getfromdataraw(conn,dataredutable,'filename', string.split(img,'/')[-1],column2='filename')
 
       if not exist or force =='update':
-         hdr=readhdr(fullpath)
-         _targetid=lsc.mysqldef.targimg(fullpath)
+         hdr = readhdr(fullpath)
+         _targetid = lsc.mysqldef.targimg(fullpath)
          try:
             _tracknumber=int(readkey3(hdr,'TRACKNUM'))
          except:


### PR DESCRIPTION
Ingesting data from SN 2019qyl, we found some files were compress with Fpack (.fz) files while others were gzipped (.gz). Ingesttar.py was failing for some of the SNEx packages because they contained .fz files. This fix allows both file types to be ingested.

# Test command:
 ingesttar.py -f snexdata_2020-08-20_22_39_23.853297_320_5971.tar.gz