### PR TITLE
adding % to the front of the sn name

### DIFF
--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -624,12 +624,7 @@ def filtralist(ll2, _filter, _id, _name, _ra, _dec, _bad, _filetype=1, _groupid=
                 ll1[jj] = []
     if _name:  # name
         _targetid = lsc.mysqldef.gettargetid(_name, '', '', conn, 0.01, False)
-        if _targetid:
-            print _targetid
-            ww = np.array([i for i in range(len(ll1['filter'])) if ((_targetid == ll1['targetid'][i]))])
-        else:
-            ww = np.array([i for i in range(len(ll1['filter'])) if ((_name in ll1['objname'][i]))])
-
+        ww = np.array([i for i in range(len(ll1['filter'])) if ((_targetid == ll1['targetid'][i]))])
         if len(ww) > 0:
             for jj in ll1.keys():
                 ll1[jj] = np.array(ll1[jj])[ww]
@@ -1725,7 +1720,7 @@ def get_standards(epoch, name, filters):
                AND std.quality = 127
                AND obj.dayobs >= {start}
                AND obj.dayobs <= {end}
-               AND targobj.id = {targetid}
+               AND targobj.targetid = {targetid}
                '''.format(start=epochs[0], end=epochs[-1], targetid=targetid)
     if filters:
         query += 'AND (obj.filter="' + '" OR obj.filter="'.join(lsc.sites.filterst[filters]) + '")'

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -1698,7 +1698,7 @@ def get_list(epoch=None, _telescope='all', _filter='', _bad='', _name='', _id=''
 
 def get_standards(epoch, name, filters):
     epochs = process_epoch(epoch)
-    flexible_name = name.lower().replace('at20', 'at20%').replace('sn20', 'sn20%').replace(' ', '%')
+    flexible_name = '%{}'.format(name.lower().replace('at20', 'at20%').replace('sn20', 'sn20%').replace(' ', '%'))
     query = '''SELECT DISTINCT std.filepath, std.filename, std.objname, std.filter,
                std.wcs, std.psf, std.psfmag, std.zcat, std.mag, std.abscat, std.lastunpacked
                FROM

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -1698,7 +1698,7 @@ def get_list(epoch=None, _telescope='all', _filter='', _bad='', _name='', _id=''
 
 def get_standards(epoch, name, filters):
     epochs = process_epoch(epoch)
-    flexible_name = '%{}'.format(name.lower().replace('at20', 'at20%').replace('sn20', 'sn20%').replace(' ', '%'))
+    targetid = lsc.mysqldef.gettargetid(name, '', '', lsc.conn)
     query = '''SELECT DISTINCT std.filepath, std.filename, std.objname, std.filter,
                std.wcs, std.psf, std.psfmag, std.zcat, std.mag, std.abscat, std.lastunpacked
                FROM
@@ -1725,8 +1725,8 @@ def get_standards(epoch, name, filters):
                AND std.quality = 127
                AND obj.dayobs >= {start}
                AND obj.dayobs <= {end}
-               AND targobj.name LIKE "{name}"
-               '''.format(start=epochs[0], end=epochs[-1], name=flexible_name)
+               AND targobj.id = {targetid}
+               '''.format(start=epochs[0], end=epochs[-1], targetid=targetid)
     if filters:
         query += 'AND (obj.filter="' + '" OR obj.filter="'.join(lsc.sites.filterst[filters]) + '")'
     print 'Searching for corresponding standard fields. This may take a minute...'

--- a/trunk/src/lsc/mysqldef.py
+++ b/trunk/src/lsc/mysqldef.py
@@ -629,9 +629,8 @@ def gettargetid(_name,_ra,_dec,conn,_radius=.01,verbose=False):
    import lsc
    from numpy import argmin
    if _name:
-        _name = _name.lower().replace('at20', 'at20%').replace('sn20', 'sn20%').replace(' ', '%')
-        command=['select distinct(r.name), r.targetid, t.id, t.ra0, t.dec0 from targetnames as r join targets as t where r.name like "'+\
-                 _name +'" and t.id=r.targetid']
+        command=['select distinct(r.name), r.targetid, t.id, t.ra0, t.dec0 from targetnames as r join targets as t where r.name like "%'+\
+                 _name.replace(' ', '%') +'" and t.id=r.targetid']
         lista=lsc.mysqldef.query(command,conn)
    elif _ra and _dec:
       if ':' in  str(_ra):


### PR DESCRIPTION
When creating a local sequence, if the sn or at is not put in front of the supernova name, then no standards are found. This PR pre-pends a % to whatever name the user provides

# Testing
In the master branch, the following should return no standards
```
lscloop.py -n 2020cxd -e 20200201-20200331 --standard all -f U -s local -i --catalog $LCOSNDIR/standard/cat/apass/SN2020cxd_apass.cat --field landolt
```
In this branch it should return standards