### PR TITLE
Add option to use reproject instead of gregister for image alignment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
 
 RUN ln -s /usr/bin/sextractor /usr/bin/sex
 
-RUN pip install cryptography==2.4.1 numpy>=1.12 astropy matplotlib==2.2.5 pyraf mysql-python scipy astroquery==v0.4 statsmodels==0.10 cython
+RUN pip install cryptography==2.4.1 numpy>=1.12 astropy matplotlib==2.2.5 pyraf mysql-python scipy astroquery==v0.4 statsmodels==0.10 cython reproject
 
 RUN pip install git+git://github.com/kbarbary/sep.git@master git+git://github.com/dguevel/PyZOGY.git && rm -rf ~/.cache/pip
 

--- a/manual.md
+++ b/manual.md
@@ -231,6 +231,7 @@ Where STANDARD is the standard you calibrated previously and CATALOG is the name
 * An outline of the steps to perform difference imaging can be found here: https://www.authorea.com/users/75900/articles/96044-image-subtraction-with-lcogtsnpipe
 * When running the `zcat` stage, `--field` is used to select the catalog to which you will calibrate the magnitudes of those images. If you do not give `--field`, it uses whatever you put in `-f` by default (which is correct for Sloan, for example).
 * When the `-s diff --difftype 1` fails with the error message `ERROR:root:Too few stars in common at 5-sigma; lower and try again` this could be the result of bad WCS, bad background subtraction, bad cosmic ray mask, bad quality image. Regardless, most of these issues are solved by adding the `--unmask` flag to ignore the bad pixel mask when looking for stars
+* An experimental feature has been added under the `--no_iraf` flag. This will use the Python package `reproject` (specifically the `reproject_interp` function) to align the images instead of using IRAF's `gregister`. We added this after experiencing problems where `gregister` does not align images correctly, but we have not looked deeply into the root cause of that problem. We think that `reproject_interp` does not use the same algorithm as `gregister`, and in fact it may use a worse algorithm, so this option should be used with caution. Note that IRAF is still used for `--fixpix` regardless of the `--no_iraf` flag.
 
 # Definitions
 ## Telescopes

--- a/trunk/bin/lscdiff.py
+++ b/trunk/bin/lscdiff.py
@@ -165,7 +165,7 @@ if __name__ == "__main__":
                         rn_targ = lsc.readkey3(head_targ, 'ron')
                         max_fwhm = head_targ.get('L1FWHM', 3.0)
 
-                        data_temp, head_temp = fits.getdata(_dir + imgtemp0, header=True)
+                        data_temp, head_temp = fits.getdata(_dirtemp + imgtemp0, header=True)
                         exp_temp = lsc.util.readkey3(head_temp, 'exptime')
                         sat_temp = lsc.util.readkey3(head_temp, 'datamax')
                         gain_temp = lsc.util.readkey3(head_temp, 'gain')

--- a/trunk/bin/lscdiff.py
+++ b/trunk/bin/lscdiff.py
@@ -172,13 +172,13 @@ if __name__ == "__main__":
                             shutil.copy(_dir + targmask0, targmask)
 
                             temp_reproj, temp_foot = reproject_interp(_dirtemp + imgtemp0, hdtar)
-                            fits.writeto(imgtarg, temp_reproj, hdtar)
+                            fits.writeto(imgtemp, temp_reproj, hdtar, overwrite=True)
 
                             tempmask_reproj, tempmask_foot = reproject_interp(_dirtemp + tempmask0, hdtar)
-                            fits.writeto(tempmask, tempmask_reproj, hdtar)
+                            fits.writeto(tempmask, tempmask_reproj, hdtar, overwrite=True)
 
                             tempnoise_reproj, tempnoise_foot = reproject_interp(_dirtemp + tempnoise0, hdtar)
-                            fits.writeto(tempnoise, tempnoise_reproj, hdtar)
+                            fits.writeto(tempnoise, tempnoise_reproj, hdtar, overwrite=True)
 
                             if args.show:
                                 fig, (ax1, ax2) = plt.subplots(1, 2)
@@ -295,7 +295,7 @@ if __name__ == "__main__":
 
                         # create mask image for template
                         mask = np.abs(data_temp) < 1e-6
-                        fits.writeto('tempmask.fits',mask.astype('i'))
+                        fits.writeto('tempmask.fits',mask.astype('i'), overwrite=True)
 
                         if args.fixpix:
                             try:

--- a/trunk/bin/lscdiff.py
+++ b/trunk/bin/lscdiff.py
@@ -190,9 +190,10 @@ if __name__ == "__main__":
                             tempmask_reproj = (tempmask_reproj > 0.) | (temp_foot == 0.)
                             fits.writeto(tempmask, tempmask_reproj.astype('uint8'), head_targ, overwrite=True)
 
-                            tempnoise_reproj, tempnoise_foot = reproject_interp(_dirtemp + tempnoise0, head_targ)
-                            tempnoise_reproj[tempmask_reproj] = sat_temp  # ~infinite variance where masked
-                            fits.writeto(tempnoise, tempnoise_reproj, head_targ, overwrite=True)
+                            if os.path.isfile(_dirtemp + tempnoise0):
+                                tempnoise_reproj, tempnoise_foot = reproject_interp(_dirtemp + tempnoise0, head_targ)
+                                tempnoise_reproj[tempmask_reproj] = sat_temp  # ~infinite variance where masked
+                                fits.writeto(tempnoise, tempnoise_reproj, head_targ, overwrite=True)
 
                         else:
                             substamplist, dict = crossmatchtwofiles(_dir + imgtarg0, _dirtemp + imgtemp0, 4)
@@ -233,7 +234,7 @@ if __name__ == "__main__":
                                 iraf.immatch.gregister(_dirtemp + tempmask0, tempmask, "tmp$db", "tmpcoo", geometr="geometric",
                                                    interpo=args.interpolation, boundar='constant', constan=0, flux='yes', verbose='yes')
 
-                            if os.path.isfile(_dirtemp + imgtemp0.replace('.fits','.var.fits')):
+                            if os.path.isfile(_dirtemp + tempnoise0):
                                 print 'variance image already there, do not create noise image'
                                 iraf.immatch.gregister(_dirtemp + tempnoise0, tempnoise, "tmp$db", "tmpcoo", geometr="geometric",
                                                    interpo=args.interpolation, boundar='constant', constan=0, flux='yes', verbose='yes')

--- a/trunk/bin/lscdiff.py
+++ b/trunk/bin/lscdiff.py
@@ -11,8 +11,7 @@ from PyZOGY.subtract import run_subtraction
 from pyraf import iraf
 from reproject import reproject_interp
 import shutil
-import matplotlib.pyplot as plt
-from astropy.visualization import ImageNormalize, ZScaleInterval
+
 
 def crossmatchtwofiles(img1, img2, radius=3):
     ''' This module is crossmatch two images:
@@ -179,13 +178,6 @@ if __name__ == "__main__":
 
                             tempnoise_reproj, tempnoise_foot = reproject_interp(_dirtemp + tempnoise0, hdtar)
                             fits.writeto(tempnoise, tempnoise_reproj, hdtar, overwrite=True)
-
-                            if args.show:
-                                fig, (ax1, ax2) = plt.subplots(1, 2)
-                                norm1 = ImageNormalize(artar, interval=ZScaleInterval())
-                                ax1.imshow(artar, norm=norm1, origin='lower')
-                                norm2 = ImageNormalize(temp_reproj, interval=ZScaleInterval())
-                                ax2.imshow(temp_reproj, norm=norm2, origin='lower')
 
                         else:
                             substamplist, dict = crossmatchtwofiles(_dir + imgtarg0, _dirtemp + imgtemp0, 4)

--- a/trunk/bin/lscloop.py
+++ b/trunk/bin/lscloop.py
@@ -277,7 +277,7 @@ if __name__ == "__main__":   # main program
 
                     listtemp = np.array([k + v for k, v in zip(lltemp['filepath'], lltemp['filename'])])
 
-                    lsc.myloopdef.run_diff(listfile, listtemp, args.show, args.force, args.normalize, args.convolve, args.bgo, args.fixpix, difftype, suffix, args.use_mask)
+                    lsc.myloopdef.run_diff(listfile, listtemp, args.show, args.force, args.normalize, args.convolve, args.bgo, args.fixpix, difftype, suffix, args.use_mask, args.no_iraf)
             elif args.stage == 'template':
                 lsc.myloopdef.run_template(listfile, args.show, args.force, args.interactive, args.RA, args.DEC, args.psf, args.mag, args.clean, args.subtract_mag_from_header)
             elif args.stage == 'mergeall':  #    merge images using lacos and swarp

--- a/trunk/setup.py
+++ b/trunk/setup.py
@@ -12,7 +12,7 @@ setup(
     license='LICENSE.txt', 
     description='lsc is a package to reduce PHTOMETRIC SN data',
     long_description=open('README.txt').read(),
-    requires=['numpy','astropy','matplotlib','MySQLdb', 'pyraf'],
+    requires=['numpy','astropy','matplotlib','MySQLdb', 'pyraf', 'reproject'],
     packages=['lsc'],
     package_dir={'': 'src'},
     package_data={'lsc': ["standard/astrometry/*cat","standard/*txt","standard/stdlist/*txt",

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -1853,7 +1853,7 @@ def run_ingestsloan(imglist,imgtype = 'sloan', ps1frames='', show=False, force=F
     os.system(command)
 
 #####################################################################
-def run_diff(listtar, listtemp, _show=False, _force=False, _normalize='i', _convolve='', _bgo=3, _fixpix=False, _difftype='0', suffix='.diff.fits', use_mask=True):
+def run_diff(listtar, listtemp, _show=False, _force=False, _normalize='i', _convolve='', _bgo=3, _fixpix=False, _difftype='0', suffix='.diff.fits', use_mask=True, no_iraf=False):
     status = []
     stat = 'psf'
     for img in listtar:
@@ -1898,7 +1898,11 @@ def run_diff(listtar, listtemp, _show=False, _force=False, _normalize='i', _conv
         mask = ''
     else:
         mask = ' --unmask'
-    command = 'lscdiff.py _tar.list _temp.list ' + ii + ff + '--normalize ' + _normalize + _convolve + _bgo + fixpix + difftype + ' --suffix ' + suffix + mask
+    if no_iraf:
+        iraf = ' --no-iraf'
+    else:
+        iraf = ''
+    command = 'lscdiff.py _tar.list _temp.list ' + ii + ff + '--normalize ' + _normalize + _convolve + _bgo + fixpix + difftype + ' --suffix ' + suffix + mask + iraf
     print command
     os.system(command)
 


### PR DESCRIPTION
@arcavi and I have both reported problems with `iraf.immatch.gregister` not aligning images correctly prior to subtraction. This might be due to temporary files...I haven't looked into it. However it was fairly easy to replace gregister with the pure-Python `reproject.reproject_interp` function associated with Astropy. This avoids the step of having to calculate the transformation, save it in a temporary file (`tmpcoo`), and then apply it to the images. I attached this to the existing `--no_iraf` option (although IRAF is still used for `fixpix`).

Possible downsides:
- adds a new dependency (`reproject`), but it's pip/conda installable
- `--show` no longer works to show the image alignment in real time, but I'm not sure if anyone used this anyway