### PR TITLE
Feature/mark psf stars checkpsf

### DIFF
--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -820,7 +820,7 @@ def mark_stars_on_image(imgfile, catfile, fig=None):
     psf_star_x, psf_star_y, psf_star_id = get_psf_star_coords(imgfile)
     ax.plot(psf_star_x, psf_star_y, 'o', mec='c', mfc='none', ls='none')
     for ipsf_star_x, ipsf_star_y, ipsf_star_id in zip(psf_star_x, psf_star_y, psf_star_id):
-        ax.text(ipsf_star_x, ipsf_star_y, ipsf_star_id, color='c')
+        ax.text(ipsf_star_x-1, ipsf_star_y-1, ipsf_star_id, color='c') #subtract 1 for iraf --> python indexing
 
 def get_psf_star_coords(imgfile):
     psf_file = imgfile.replace('.fits', '.psf.fits')

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -818,9 +818,9 @@ def mark_stars_on_image(imgfile, catfile, fig=None):
     ax.set_title(os.path.basename(imgfile))
     fig.tight_layout()
     psf_star_x, psf_star_y, psf_star_id = get_psf_star_coords(imgfile)
-    ax.plot(psf_star_x, psf_star_y, 'o', mec='c', mfc='none', ls='none')
+    ax.plot(psf_star_x-1, psf_star_y-1, 'o', mec='c', mfc='none', ls='none') #subtract 1 for iraf --> python indexing
     for ipsf_star_x, ipsf_star_y, ipsf_star_id in zip(psf_star_x, psf_star_y, psf_star_id):
-        ax.text(ipsf_star_x-1, ipsf_star_y-1, ipsf_star_id, color='c') #subtract 1 for iraf --> python indexing
+        ax.text(ipsf_star_x-1, ipsf_star_y-1, ipsf_star_id, color='c') 
 
 def get_psf_star_coords(imgfile):
     psf_file = imgfile.replace('.fits', '.psf.fits')

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -817,7 +817,22 @@ def mark_stars_on_image(imgfile, catfile, fig=None):
     ax.plot(i, j, marker='o', mec='r', mfc='none', ls='none')
     ax.set_title(os.path.basename(imgfile))
     fig.tight_layout()
+    psf_star_x, psf_star_y, psf_star_id = get_psf_star_coords(imgfile)
+    ax.plot(psf_star_x, psf_star_y, 'o', mec='c', mfc='none', ls='none')
+    ax.text(psf_star_x, psf_star_y, psf_star_id, color='c')
 
+def get_psf_star_coords(imgfile):
+    psf_file = imgfile.replace('.fits', '.psf.fits')
+    psf_hdr = fits.getheader(psf_file, 0)
+    i = 0
+    id = []
+    x = []
+    y = []
+    while 'X{}'.format(i) in psf_hdr.keys():
+        id.append('ID{}'.format(i))
+        x.append('X{}'.format(i))
+        y.append('Y{}'.format(i))
+    return x, y, id
 
 def checkcat(imglist, database='photlco'):
     plt.ion()

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -805,7 +805,7 @@ def mark_stars_on_image(imgfile, catfile, fig=None):
     fig.clf()
     ax = fig.add_subplot(1, 1, 1)
     norm = ImageNormalize(data, interval=ZScaleInterval())
-    ax.imshow(data, norm=norm, origin='lower')
+    ax.imshow(data, norm=norm, origin='lower', cmap='bone')
     wcs = WCS(hdr)
     if catfile.endswith('fits'):
         cat = Table.read(catfile)
@@ -819,7 +819,8 @@ def mark_stars_on_image(imgfile, catfile, fig=None):
     fig.tight_layout()
     psf_star_x, psf_star_y, psf_star_id = get_psf_star_coords(imgfile)
     ax.plot(psf_star_x, psf_star_y, 'o', mec='c', mfc='none', ls='none')
-    ax.text(psf_star_x, psf_star_y, psf_star_id, color='c')
+    for ipsf_star_x, ipsf_star_y, ipsf_star_id in zip(psf_star_x, psf_star_y, psf_star_id):
+        ax.text(ipsf_star_x, ipsf_star_y, ipsf_star_id, color='c')
 
 def get_psf_star_coords(imgfile):
     psf_file = imgfile.replace('.fits', '.psf.fits')

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -829,9 +829,9 @@ def get_psf_star_coords(imgfile):
     x = []
     y = []
     while 'X{}'.format(i) in psf_hdr.keys():
-        id.append('ID{}'.format(i))
-        x.append('X{}'.format(i))
-        y.append('Y{}'.format(i))
+        id.append(str(psf_hdr['ID{}'.format(i)]))
+        x.append(psf_hdr['X{}'.format(i)])
+        y.append(psf_hdr['Y{}'.format(i)])
     return x, y, id
 
 def checkcat(imglist, database='photlco'):

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -824,7 +824,7 @@ def mark_stars_on_image(imgfile, catfile, fig=None):
 def get_psf_star_coords(imgfile):
     psf_file = imgfile.replace('.fits', '.psf.fits')
     psf_hdr = fits.getheader(psf_file, 0)
-    i = 0
+    i = 1
     id = []
     x = []
     y = []

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -834,6 +834,8 @@ def get_psf_star_coords(imgfile):
         x.append(psf_hdr['X{}'.format(i)])
         y.append(psf_hdr['Y{}'.format(i)])
         i+=1
+    x = np.array(x)
+    y = np.array(y)
     return x, y, id
 
 def checkcat(imglist, database='photlco'):

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -825,17 +825,15 @@ def mark_stars_on_image(imgfile, catfile, fig=None):
 def get_psf_star_coords(imgfile):
     psf_file = imgfile.replace('.fits', '.psf.fits')
     psf_hdr = fits.getheader(psf_file, 0)
-    i = 1
+    npsfstars = psf_hdr['NPSFSTAR']
     id = []
-    x = []
-    y = []
-    while 'X{}'.format(i) in psf_hdr.keys():
-        id.append(str(psf_hdr['ID{}'.format(i)]))
-        x.append(psf_hdr['X{}'.format(i)])
-        y.append(psf_hdr['Y{}'.format(i)])
-        i+=1
-    x = np.array(x)
-    y = np.array(y)
+    x = np.empty(npsfstars)
+    y = np.empty(npsfstars)
+    for indx in range(npsfstars):
+        starnum = indx+1
+        id.append(psf_hdr['ID{}'.format(starnum)])
+        x[indx] = psf_hdr['X{}'.format(starnum)]
+        y[indx] = psf_hdr['Y{}'.format(starnum)]
     return x, y, id
 
 def checkcat(imglist, database='photlco'):

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -832,6 +832,7 @@ def get_psf_star_coords(imgfile):
         id.append(str(psf_hdr['ID{}'.format(i)]))
         x.append(psf_hdr['X{}'.format(i)])
         y.append(psf_hdr['Y{}'.format(i)])
+        i+=1
     return x, y, id
 
 def checkcat(imglist, database='photlco'):


### PR DESCRIPTION
This PR implements the marking of the stars used to build the PSF in the checkpsf stage when the --no_iraf option is used

Testing:
Running the following command should show you the PSF stars marked on the image in cyan and all other catalog stars in red.
```
lscloop.py -n "SN 2016cok" -e 20160530  -s checkpsf --show --no_iraf
```