### PR TITLE
Add gaia catalogs for psf stage

### DIFF
--- a/supernova.sql
+++ b/supernova.sql
@@ -1042,6 +1042,7 @@ CREATE TABLE `targets` (
   `sloan_cat` text,
   `landolt_cat` text,
   `apass_cat` text,
+  `gaia_cat` text,
   `pm_ra` double NOT NULL DEFAULT '0' COMMENT 'proper motion RA times cos(dec)',
   `pm_dec` double NOT NULL DEFAULT '0' COMMENT 'proper motion Dec',
   `groupidcode` bigint(20) NOT NULL DEFAULT '32769' COMMENT 'Which groups can see this',

--- a/trunk/bin/comparecatalogs.py
+++ b/trunk/bin/comparecatalogs.py
@@ -9,7 +9,8 @@ default_catdir = os.path.join(os.getenv('LCOSNDIR', lsc.util.workdirectory), 'st
 parser = argparse.ArgumentParser()
 parser.add_argument('-F', '--force', action='store_true', help="try to download catalog even if we've tried before")
 parser.add_argument('-R', '--radius', type=float, default=20., help="query for stars within this radius of the coordinates")
-parser.add_argument('-f', '--field', nargs='+', choices=['landolt', 'apass', 'sloan'], default=['landolt', 'apass', 'sloan'], help="catalogs to check (all by default)")
+parser.add_argument('-f', '--field', nargs='+', choices=['landolt', 'apass', 'sloan', 'gaia'],
+        default=['landolt', 'apass', 'sloan', 'gaia'], help="catalogs to check (all by default)")
 args = parser.parse_args()
 
 if args.force:
@@ -40,6 +41,9 @@ for system in args.field:
                 os.system('queryapasscat.py -r {ra0} -d {dec0} -R {radius} -o '.format(radius=args.radius, **target) + os.path.join(filepath, filename))
             elif system == 'sloan':
                 lsc.lscabsphotdef.sloan2file(target['ra0'], target['dec0'], args.radius, output=os.path.join(filepath, filename))
+            elif system == 'gaia':
+                lsc.lscabsphotdef.gaia2file(target['ra0'], target['dec0'],
+                        output=os.path.join(filepath, filename))
             fileexists = os.path.isfile(os.path.join(filepath, filename))
             if fileexists:
                 print 'Adding', filename, 'to database'

--- a/trunk/bin/lscloop.py
+++ b/trunk/bin/lscloop.py
@@ -48,7 +48,8 @@ if __name__ == "__main__":   # main program
     parser.add_argument("-c", "--center", action="store_false", dest='recenter', help='do not recenter')
     parser.add_argument("--unfix", action="store_false", dest='fix', help='use a variable color term')
     parser.add_argument("--cutmag", default=99., type=float, help='magnitude instrumental cut for zeropoint')
-    parser.add_argument("--field", default='', choices=['landolt', 'sloan', 'apass'])
+    parser.add_argument("--field", default='', choices=['landolt', 'sloan', 'apass', 'gaia'],
+            help='note: gaia only functional for psf stage')
     parser.add_argument("--ref", default='', help='get sn position from this file')
     parser.add_argument("--use-sextractor", action="store_true", help="use souces from sextractor for PSF instead of catalog")
     parser.add_argument("--catalogue", default='', help="filename of catalog (full path OR ./___apass.cat OR apass/___apass.cat)")
@@ -184,7 +185,8 @@ if __name__ == "__main__":   # main program
             elif args.stage == 'getmag':  # get final magnitude from mysql
                 lsc.myloopdef.run_getmag(ll['filename'], args.output, args.interactive, args.show, args.combine, args.type)
             elif args.stage == 'psf':
-                lsc.myloopdef.run_psf(ll['filename'], args.threshold, args.interactive, args.fwhm, args.show, args.force, args.fix, args.catalogue,
+                catalogue = lsc.util.getcatalog(args.name, args.field) if args.field else args.catalogue
+                lsc.myloopdef.run_psf(ll['filename'], args.threshold, args.interactive, args.fwhm, args.show, args.force, args.fix, catalogue,
                                       'photlco', args.use_sextractor, args.datamin, args.datamax, args.nstars, args.banzai, args.b_sigma, args.b_crlim, 
                                       max_apercorr=args.max_apercorr)
             elif args.stage == 'psfmag':

--- a/trunk/bin/lscloop.py
+++ b/trunk/bin/lscloop.py
@@ -223,6 +223,10 @@ if __name__ == "__main__":   # main program
                     p.join()
                 else:                    
                     for img in listfile:
+                        if args.field == 'gaia':
+                            print('Cannot use gaia catalog for zcat stage: ' 
+                                  'use apass or sloan instead')
+                            continue
                         run_absphot(img)
             elif args.stage in ['mag', 'abscat', 'local']:  # compute magnitudes for sequence stars or supernova
                 # Don't allow PSF photometry to be performed on difference images becaues of complications with aperture correction

--- a/trunk/bin/lscpsf.py
+++ b/trunk/bin/lscpsf.py
@@ -83,8 +83,7 @@ if __name__ == "__main__":
                 elif option.catalog:
                     catalog = option.catalog
                 else:
-                    for system in ['sloan', 'apass', 'landolt']:
-                        #catalog = lsc.util.getcatalog(img, system)
+                    for system in ['gaia', 'sloan', 'apass', 'landolt']:
                         catalog = lsc.util.getcatalog(img.split('/')[-1], system)
                         if catalog:
                             break

--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -1164,7 +1164,7 @@ def gaia2file(ra, dec, size=26., mag_limit=18., output='gaia.cat'):
 
     response = response[
             (response['phot_g_mean_mag'] < mag_limit) &
-            (response['parallax'] > 0)  # ignore extragalactic sources
+            (response['astrometric_excess_noise_sig'] < 2) # filter objects with bad astrometry (e.g. HII regions in galaxies)
     ]
     response['ra'].format ='%16.12f'
     response['dec'].format = '%16.12f'

--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -1151,7 +1151,7 @@ def sloan2file(ra, dec, radius=10., mag1=13., mag2=20., output='sloan.cat'):
     else:
         print 'No matching objects.'
 #######################################################################
-def gaia2file(ra, dec, width=26., mag1=13., mag2=20., output='gaia.cat'):
+def gaia2file(ra, dec, width=26., mag1=13., mag2=19., output='gaia.cat'):
 
     from astroquery.gaia import Gaia
 
@@ -1163,7 +1163,8 @@ def gaia2file(ra, dec, width=26., mag1=13., mag2=20., output='gaia.cat'):
 
     response = response[
             (response['phot_g_mean_mag'] > mag1) &
-            (response['phot_g_mean_mag'] < mag2)
+            (response['phot_g_mean_mag'] < mag2) &
+            (response['parallax'] > 0)  # ignore extragalactic sources
     ]
     response['ra'].format ='%16.12f'
     response['dec'].format = '%16.12f'

--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -1151,7 +1151,7 @@ def sloan2file(ra, dec, radius=10., mag1=13., mag2=20., output='sloan.cat'):
     else:
         print 'No matching objects.'
 #######################################################################
-def gaia2file(ra, dec, width=26., mag1=13., mag2=19., output='gaia.cat'):
+def gaia2file(ra, dec, size=26., mag1=13., mag2=19., output='gaia.cat'):
 
     from astroquery.gaia import Gaia
 

--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -1151,7 +1151,7 @@ def sloan2file(ra, dec, radius=10., mag1=13., mag2=20., output='sloan.cat'):
     else:
         print 'No matching objects.'
 #######################################################################
-def gaia2file(ra, dec, size=26., mag1=13., mag2=19., output='gaia.cat'):
+def gaia2file(ra, dec, size=26., mag_limit=18., output='gaia.cat'):
 
     from astroquery.gaia import Gaia
 
@@ -1163,8 +1163,7 @@ def gaia2file(ra, dec, size=26., mag1=13., mag2=19., output='gaia.cat'):
     response = Gaia.query_object_async(coordinate=coord, width=width, height=height)
 
     response = response[
-            (response['phot_g_mean_mag'] > mag1) &
-            (response['phot_g_mean_mag'] < mag2) &
+            (response['phot_g_mean_mag'] < mag_limit) &
             (response['parallax'] > 0)  # ignore extragalactic sources
     ]
     response['ra'].format ='%16.12f'

--- a/trunk/src/lsc/sites.py
+++ b/trunk/src/lsc/sites.py
@@ -32,6 +32,7 @@ for key, val in filterst.items():
 filterst['landolt'] = sum([filterst[f] for f in 'UBVRI'], [])
 filterst['sloan'] = sum([filterst[f] for f in 'ugrizw'], [])
 filterst['apass'] = sum([filterst[f] for f in 'BVgriw'], [])
+filterst['gaia'] = sum([filterst[f] for f in filterst.keys()], [])
 filterst[''] = filterst['landolt'] + filterst['sloan']
 
 def chosecolor(allfilter, usegood=False):

--- a/trunk/src/lsc/util.py
+++ b/trunk/src/lsc/util.py
@@ -806,12 +806,14 @@ def getcatalog(name_or_filename, field='', return_field=False):
     catalog = ''
     # get the catalog(s) from the database
     if '.fits' in name_or_filename:
-        entries = lsc.mysqldef.query(['''select name, sloan_cat, landolt_cat, apass_cat, filter
+        entries = lsc.mysqldef.query(['''select name, sloan_cat, landolt_cat, apass_cat,
+                                         gaia_cat, filter
                                          from targets, targetnames, photlco
                                          where targets.id=targetnames.targetid and targets.id=photlco.targetid
                                          and filename="{}"'''.format(name_or_filename)], lsc.conn)
     else:
-        entries = lsc.mysqldef.query(['''select othernames.name, sloan_cat, landolt_cat, apass_cat
+        entries = lsc.mysqldef.query(['''select othernames.name, sloan_cat, landolt_cat,
+                                         apass_cat, gaia_cat
                                          from targets, targetnames, targetnames as othernames
                                          where targets.id=targetnames.targetid and targets.id=othernames.targetid
                                          and targetnames.name="{}"'''.format(name_or_filename)], lsc.conn)


### PR DESCRIPTION
This PR:
1. Adds a column for gaia catalogs to the targets table of the db.
2. Changes `compare_catalogs.py` so that column gets populated.
3. Makes gaia catalogs the default selection for the psf stage, to alleviate problems with apass/sloan catalogs selecting galaxies.

This could use further testing, especially `compare_catalogs.py` -- I was having difficulty forcing re-ingestion of catalogs when I was tweaking values in that script, so making sure that it's properly functioning would be good. I also only tested the psf stage on the two targets that I had already ingested into my db (20hvf and 19yvq), and they're both pretty similar objects in medium density stellar fields offset from  an angularly small host. I'll ingest data from some more varied targets to make sure the catalogs work in a wider variety of cases.