### PR TITLE
Upload photometry to snex2

### DIFF
--- a/trunk/bin/format_snex2.py
+++ b/trunk/bin/format_snex2.py
@@ -22,7 +22,7 @@ for row in phot:
                                                       mag=mag, dmag=dmag))
 
 [filename_root, ext] = splitext(args.name)
-filename_snex2 = filename_root + '_snex2' + ext
+filename_snex2 = filename_root + '_snex2' + '.csv'
 print 'Saving new file as {name}'.format(name=filename_snex2)
 with open(filename_snex2, 'w') as f:
     for line in lines:

--- a/trunk/bin/lscloop.py
+++ b/trunk/bin/lscloop.py
@@ -91,6 +91,7 @@ if __name__ == "__main__":   # main program
     parser.add_argument("--b_crlim", type=float, default=3.0, help="lower limit used to reject CRs identified as BANZAI sources")
     parser.add_argument("--no_iraf", action="store_true", help="Don't use iraf (currently only option in checkpsf stage)")
     parser.add_argument("--max_apercorr", type=float, default=0.1, help="absolute value of the maximum aperture correction (mag) above which a PSF is marked as bad")
+    parser.add_argument("--uploadtosnex2", action="store_true", help="Upload the selected data points to SNEx2")
 
     args = parser.parse_args()
     if args.multicore >= cpu_count():
@@ -182,7 +183,7 @@ if __name__ == "__main__":   # main program
                 query = 'update photlco set lastunpacked=NULL where filename="' + '" or filename="'.join(packed) + '"'
                 lsc.mysqldef.query([query], lsc.conn)
             elif args.stage == 'getmag':  # get final magnitude from mysql
-                lsc.myloopdef.run_getmag(ll['filename'], args.output, args.interactive, args.show, args.combine, args.type)
+                lsc.myloopdef.run_getmag(ll['filename'], args.output, args.interactive, args.show, args.combine, args.type, args.uploadtosnex2)
             elif args.stage == 'psf':
                 lsc.myloopdef.run_psf(ll['filename'], args.threshold, args.interactive, args.fwhm, args.show, args.force, args.fix, args.catalogue,
                                       'photlco', args.use_sextractor, args.datamin, args.datamax, args.nstars, args.banzai, args.b_sigma, args.b_crlim, 

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -168,18 +168,27 @@ def run_getmag(imglist, _output='', _interactive=False, _show=False, _bin=1e-10,
             }
 
             if int(ftype)==1:
-                phot_type = raw_input('The default photometry type for non-difference imaging is PSF. If Aperture photometry was performed instead, please enter "Aperture". Otherwise press enter: ')
+                phot_type = raw_input('The default photometry type for non-difference imaging is PSF. If this is not PSF photometry please enter "Aperture", "Mixed", or "Unsure": ')
                 if phot_type.lower() == 'aperture':
                     upload_extras['photometry_type'] = 'Aperture'
+                elif phot_type.lower() == 'mixed':
+                    upload_extras['photometry_type'] = 'Mixed'
+                elif phot_type.lower() == 'unsure':
+                    upload_extras['photometry_type'] = 'Unsure'
                 else:
                     upload_extras['photometry_type'] = 'PSF'
                     
             elif int(ftype)==3:
-                phot_type = raw_input('The default photometry type for difference imaging is Aperture. If PSF photometry was performed instead, please enter "PSF". Otherwise press enter: ')
+                phot_type = raw_input('The default photometry type for difference imaging is Aperture. If this is not Aperture photometry please enter "PSF", "Mixed", or "Unsure": ')
                 if phot_type.lower() == 'psf':
                     upload_extras['photometry_type'] = 'PSF'
+                elif phot_type.lower() == 'mixed':
+                    upload_extras['photometry_type'] = 'Mixed'
+                elif phot_type.lower() == 'unsure':
+                    upload_extras['photometry_type'] = 'Unsure'
                 else:
                     upload_extras['photometry_type'] = 'Aperture'
+
                 upload_extras['background_subtracted'] = True
                 if int(dtype)==0:
                     upload_extras['subtraction_algorithm'] = 'Hotpants'
@@ -199,12 +208,14 @@ def run_getmag(imglist, _output='', _interactive=False, _show=False, _bin=1e-10,
                 upload_extras['final_reduction'] = True
             else:
                 upload_extras['final_reduction'] = False
-            used_in = raw_input('Will this data be used in a paper? If so, please enter the last name of the first author: ')
+            used_in = raw_input('Will this data be used in a paper? If so, please enter the name of the first author like "Last Name, First Name": ')
             if used_in:
                 upload_extras['used_in'] = used_in
             print(upload_extras)
-            
-            print('This dataproduct will be assigned to the default sharing groups. If you would like to change these group permissions, you can do so on the page for this target on SNEx2.')
+            default_groups = [
+                'ANU', 'ARIES', 'CSP', 'CU Boulder', 'e/PESSTO', 'ex-LCOGT', 'KMTNet', 'LBNL', 'LCOGT', 'LSQ', 'NAOC', 'Padova', 'QUB', 'SAAO', 'SIRAH', 'Skymapper', 'Tel Aviv U', 'U Penn', 'UC Berkeley', 'US GSP', 'UT Austin'
+            ]
+            print('This dataproduct will be assigned to the following groups. If you would like to change these group permissions, you can do so on the page for this target on SNEx2: {}'.format(default_groups))
             ### Upload to snex2
             username = raw_input('Please enter your SNEx2 username: ')
             password = getpass.getpass(prompt='Please enter your SNEx2 password: ')

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -166,11 +166,20 @@ def run_getmag(imglist, _output='', _interactive=False, _show=False, _bin=1e-10,
                 'reduction_type': 'manual',
                 'instrument': 'LCO'
             }
-            if mtype == 'apmag':
-                upload_extras['photometry_type'] = 'Aperture'
-            else:
-                upload_extras['photometry_type'] = 'PSF'
-            if int(ftype)==3:
+
+            if int(ftype)==1:
+                phot_type = raw_input('The default photometry type for non-difference imaging is PSF. If Aperture photometry was performed instead, please enter "Aperture". Otherwise press enter: ')
+                if phot_type.lower() == 'aperture':
+                    upload_extras['photometry_type'] = 'Aperture'
+                else:
+                    upload_extras['photometry_type'] = 'PSF'
+                    
+            elif int(ftype)==3:
+                phot_type = raw_input('The default photometry type for difference imaging is Aperture. If PSF photometry was performed instead, please enter "PSF". Otherwise press enter: ')
+                if phot_type.lower() == 'psf':
+                    upload_extras['photometry_type'] = 'PSF'
+                else:
+                    upload_extras['photometry_type'] = 'Aperture'
                 upload_extras['background_subtracted'] = True
                 if int(dtype)==0:
                     upload_extras['subtraction_algorithm'] = 'Hotpants'
@@ -190,7 +199,7 @@ def run_getmag(imglist, _output='', _interactive=False, _show=False, _bin=1e-10,
                 upload_extras['final_reduction'] = True
             else:
                 upload_extras['final_reduction'] = False
-            used_in = raw_input('Is this paper used in a paper? If so, please enter the last name of the first author: ')
+            used_in = raw_input('Will this data be used in a paper? If so, please enter the last name of the first author: ')
             if used_in:
                 upload_extras['used_in'] = used_in
             print(upload_extras)

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -212,6 +212,7 @@ def run_getmag(imglist, _output='', _interactive=False, _show=False, _bin=1e-10,
             if used_in:
                 upload_extras['used_in'] = used_in
             print(upload_extras)
+            print("\n")
             default_groups = [
                 'ANU', 'ARIES', 'CSP', 'CU Boulder', 'e/PESSTO', 'ex-LCOGT', 'KMTNet', 'LBNL', 'LCOGT', 'LSQ', 'NAOC', 'Padova', 'QUB', 'SAAO', 'SIRAH', 'Skymapper', 'Tel Aviv U', 'U Penn', 'UC Berkeley', 'US GSP', 'UT Austin'
             ]


### PR DESCRIPTION
This PR allows users to upload their reduced photometry to SNEx2. Uploading can be done using the `--uploadtosnex2` flag in the `-s getmag` stage like this: 

`lscloop.py -n sn2019ein -e 20190501 -s getmag --type mag -o sn2019ein.dat --uploadtosnex2`

This flag takes the output file written during this stage (in this case, `sn2019ein.dat`), formats it in a SNEx2-readable format, and uploads it to SNEx2. It checks whether the selected photometry is background subtracted or not, and if so what subtraction algorithm was used. It also asks the user for additional input, including what group the user belongs to (i.e. LCO, UC Davis, etc.), if this is the final version of the data, if this data is used in any papers, and for the user's SNEx2 username and password.

As part of this PR, I changed the `format_snex2.py` script to always output a csv file. 