### PR TITLE
Bugfix/variance images

### DIFF
--- a/trunk/bin/lscdiff.py
+++ b/trunk/bin/lscdiff.py
@@ -268,10 +268,9 @@ if __name__ == "__main__":
                                 iraf.immatch.gregister(_dirtemp + tempmask0, tempmask, "tmp$db", "tmpcoo", geometr="geometric",
                                                    interpo=args.interpolation, boundar='constant', constan=0, flux='yes', verbose='yes')
 
-                            if os.path.isfile(_dirtemp + tempnoise0):
-                                print 'variance image already there, do not create noise image'
-                                iraf.immatch.gregister(_dirtemp + tempnoise0, tempnoise, "tmp$db", "tmpcoo", geometr="geometric",
-                                                   interpo=args.interpolation, boundar='constant', constan=0, flux='yes', verbose='yes')
+                            print 'variance image already there, do not create noise image'
+                            iraf.immatch.gregister(_dirtemp + tempnoise0, tempnoise, "tmp$db", "tmpcoo", geometr="geometric",
+                                               interpo=args.interpolation, boundar='constant', constan=0, flux='yes', verbose='yes')
 
                             if args.show:
                                 iraf.set(stdimage='imt2048')

--- a/trunk/bin/lscdiff.py
+++ b/trunk/bin/lscdiff.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
                         noise = 1.4826*np.median(np.abs(data_targ - median))
                         pssl_targ = gain_targ*noise**2 - rn_targ**2/gain_targ - median
                         noiseimg = data_targ + pssl_targ + rn_targ**2
-                        targmask_data = fits.getdata(targmask)
+                        targmask_data = fits.getdata(_dir + targmask0)
                         if noiseimg.size == targmask_data.size:
                             noiseimg[targmask_data > 0] = sat_targ
                         else:
@@ -200,7 +200,7 @@ if __name__ == "__main__":
                             noise = 1.4826*np.median(np.abs(data_temp - median))
                             pssl_temp = gain_temp*noise**2 - rn_temp**2/gain_temp - median
                             noiseimg = data_temp + pssl_temp + rn_temp**2
-                            tempmask_data = fits.getdata(tempmask)
+                            tempmask_data = fits.getdata(_dirtemp + tempmask0)
                             if noiseimg.size == tempmask_data.size:
                                 noiseimg[tempmask_data > 0] = sat_temp
                             else:


### PR DESCRIPTION
The noise image was being created after gregister resized images from the original size images. This moves the creation to before gregister and then resizes the noise image.

This issue was discovered when trying to process SBIG images with a Sinistro template and `noiseimg.size != tempmask_data.size` because `noiseimg` was created from `data_temp` which was read in before `gregister` was run but `tempmask_data` was read in from `tempmask`, which is the output of `gregister`. Thus if the image and the template were different sizes and `gregister` changed the size of the template, `noiseimg` and `tempmask_data` were different sizes. Its not clear to me why this ever worked. Its possible only a subset of the `noiseimg` was being updated when `noiseimg` was bigger than `tempmask_data`. I believe PR #45 caught these cases and skipped them, which is when the issue came to my attention.

Testing:
Prior to this PR the following command:
```
lscloop.py -n 2016cok -e 20160529 --normalize t -T kb --temptel fl --tempdate 20171231 --fixpix -s diff --difftype 0 -F  -f r -d 115
```
Failed to process the difference image with the following message:
```
Template noise image and mask are different sizes ((4096, 4096) vs (2038, 2028)), moving onto next image
```

With this PR, that command runs and produces as reasonable subtraction when viewed with `checkdiff`. Additionally, I tested that an external template (SDSS) works with the following commands:
```
lscloop.py -n 2016cok -e 20160529 -d 115 -s ingestsloan
lscloop.py -n 2016cok -e 20030128 --filetype 4 -s psf --show --fwhm 5 --use-sextractor
lscloop.py -n 2016cok -e 20030128 --filetype 4 -s cosmic
lscloop.py -n 2016cok -e 20160529 --normalize t -T kb --temptel SDSS --tempdate 20030128 --fixpix -s diff --difftype 0 -F  -f r -d 115
```

This has been tested on dark, so a quick test at LCO and it should be ready to merge