### PR TITLE
changing display of difference image from percentile to zscale

### DIFF
--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -1223,10 +1223,9 @@ def display_subtraction(img):
         ax1 = plt.subplot(2, 2, 1, adjustable='box-forced')
         ax2 = plt.subplot(2, 2, 2, sharex=ax1, sharey=ax1, adjustable='box-forced')
         ax3 = plt.subplot(2, 2, 3, sharex=ax1, sharey=ax1, adjustable='box-forced')
-        pmin, pmax = 5, 99
-        ax1.imshow(origdata, vmin=np.percentile(origdata, pmin), vmax=np.percentile(origdata, pmax))
-        ax2.imshow(tempdata, vmin=np.percentile(tempdata, pmin), vmax=np.percentile(tempdata, pmax))
-        ax3.imshow(diffdata, vmin=np.percentile(diffdata, pmin), vmax=np.percentile(diffdata, pmax))
+        ax1.imshow(origdata, norm = ImageNormalize(origdata, interval=ZScaleInterval()))
+        ax2.imshow(tempdata, norm = ImageNormalize(tempdata, interval=ZScaleInterval()))
+        ax3.imshow(diffdata, norm = ImageNormalize(diffdata, interval=ZScaleInterval()))
         basename = origimg.split('.')[0]
         ax1.set_title(origimg.replace(basename, ''))
         ax2.set_title(tempimg.replace(basename, ''))

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -1223,9 +1223,9 @@ def display_subtraction(img):
         ax1 = plt.subplot(2, 2, 1, adjustable='box-forced')
         ax2 = plt.subplot(2, 2, 2, sharex=ax1, sharey=ax1, adjustable='box-forced')
         ax3 = plt.subplot(2, 2, 3, sharex=ax1, sharey=ax1, adjustable='box-forced')
-        ax1.imshow(origdata, norm = ImageNormalize(origdata, interval=ZScaleInterval()))
-        ax2.imshow(tempdata, norm = ImageNormalize(tempdata, interval=ZScaleInterval()))
-        ax3.imshow(diffdata, norm = ImageNormalize(diffdata, interval=ZScaleInterval()))
+        ax1.imshow(origdata, origin='lower', norm=ImageNormalize(origdata, interval=ZScaleInterval()))
+        ax2.imshow(tempdata, origin='lower', norm=ImageNormalize(tempdata, interval=ZScaleInterval()))
+        ax3.imshow(diffdata, origin='lower', norm=ImageNormalize(diffdata, interval=ZScaleInterval()))
         basename = origimg.split('.')[0]
         ax1.set_title(origimg.replace(basename, ''))
         ax2.set_title(tempimg.replace(basename, ''))


### PR DESCRIPTION
This change occurs during the interactive `getmag` stage when inspecting details of an individual photometry point produced by difference imaging.

Tested on Dark with the following command, then clicking on an individual photometry point:
```
lscloop.py -n "2017gaw" -e 20170813-20200701 --filetype 3 -s getmag --difftype 0  --show --type mag -f g
```
but this can be tested on any supernova with difference imaging