### PR TITLE
adding --pixstack_limit flag

### DIFF
--- a/trunk/bin/lscdiff.py
+++ b/trunk/bin/lscdiff.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
     parser.add_argument("--unmask", action='store_false', dest='use_mask', help='do not use mask for PyZOGY gain calculation')
     parser.add_argument("--no-iraf", action='store_true', help='transform images in Python instead of IRAF'
                                                                '(IRAF is still used for fixpix if run with --fixpix)')
+    parser.add_argument('--pixstack-limit', dest='pixstack_limit', type=int, help='Modify set_extract_pixstack in Sep', default=None)
 
     args = parser.parse_args()
     imglisttar = lsc.util.readlist(args.targlist)
@@ -352,7 +353,8 @@ if __name__ == "__main__":
                                                            output=imgout,
                                                            normalization=args.normalize,
                                                            show=args.show,
-                                                           use_mask_for_gain=args.use_mask)
+                                                           use_mask_for_gain=args.use_mask,
+                                                           pixstack_limit=args.pixstack_limit)
                             except Exception as e:
                                 print e
                                 print 'PyZOGY failed on', imgtarg0

--- a/trunk/bin/lscloop.py
+++ b/trunk/bin/lscloop.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":   # main program
     parser.add_argument("--no_iraf", action="store_true", help="Don't use iraf (currently only option in checkpsf stage)")
     parser.add_argument("--max_apercorr", type=float, default=0.1, help="absolute value of the maximum aperture correction (mag) above which a PSF is marked as bad")
     parser.add_argument("--uploadtosnex2", action="store_true", help="Upload the selected data points to SNEx2")
-
+    parser.add_argument('--pixstack-limit', dest='pixstack_limit', type=int, help='Modify set_extract_pixstack in sep via PyZOGY', default=None)
     args = parser.parse_args()
     if args.multicore >= cpu_count():
         args.multicore = cpu_count()-1 if cpu_count() > 1 else 1
@@ -290,7 +290,7 @@ if __name__ == "__main__":   # main program
 
                 listtemp = np.array([k + v for k, v in zip(lltemp['filepath'], lltemp['filename'])])
 
-                lsc.myloopdef.run_diff(listfile, listtemp, args.show, args.force, args.normalize, args.convolve, args.bgo, args.fixpix, args.difftype, suffix, args.use_mask, args.no_iraf)
+                lsc.myloopdef.run_diff(listfile, listtemp, args.show, args.force, args.normalize, args.convolve, args.bgo, args.fixpix, args.difftype, suffix, args.use_mask, args.no_iraf, pixstack_limit=args.pixstack_limit)
             elif args.stage == 'template':
                 lsc.myloopdef.run_template(listfile, args.show, args.force, args.interactive, args.RA, args.DEC, args.psf, args.mag, args.clean, args.subtract_mag_from_header)
             elif args.stage == 'mergeall':  #    merge images using lacos and swarp

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -1962,7 +1962,8 @@ def run_ingestsloan(imglist,imgtype = 'sloan', ps1frames='', show=False, force=F
     os.system(command)
 
 #####################################################################
-def run_diff(listtar, listtemp, _show=False, _force=False, _normalize='i', _convolve='', _bgo=3, _fixpix=False, _difftype=None, suffix='.diff.fits', use_mask=True, no_iraf=False):
+def run_diff(listtar, listtemp, _show=False, _force=False, _normalize='i', _convolve='', _bgo=3, _fixpix=False, _difftype=None, suffix='.diff.fits', 
+             use_mask=True, no_iraf=False, pixstack_limit=None):
     status = []
     stat = 'psf'
     for img in listtar:
@@ -2011,7 +2012,11 @@ def run_diff(listtar, listtemp, _show=False, _force=False, _normalize='i', _conv
         iraf = ' --no-iraf'
     else:
         iraf = ''
-    command = 'lscdiff.py _tar.list _temp.list ' + ii + ff + '--normalize ' + _normalize + _convolve + _bgo + fixpix + difftype + ' --suffix ' + suffix + mask + iraf
+    if pixstack_limit is not None:
+        pixstack_text = ' --pixstack-limit {}'.format(pixstack_limit)
+    else:
+        pixstack_text = ''
+    command = 'lscdiff.py _tar.list _temp.list ' + ii + ff + '--normalize ' + _normalize + _convolve + _bgo + fixpix + difftype + ' --suffix ' + suffix + mask + iraf + pixstack_text
     print command
     os.system(command)
 


### PR DESCRIPTION
## **NOTE** This PR cannot be merged until after [PyZOGY PR #4](https://github.com/dguevel/PyZOGY/pull/4)

When PyZOGY was run on some images with a lot of sources, the default number of active pixel sources (science.size//20) allowed by sep was exceeded with the error:

> Exception: internal pixel buffer full: The limit of 838860 active object pixels over the detection threshold was reached. Check that the image is background subtracted and the detection threshold is not too low. If you need to increase the limit, use set_extract_pixstack.

This PR adds the flag --pixstack-limit so that the user can manually push this limit higher. 

## Testing

This PR was tested by first running images without the --pixstack flag to demonstrate that the error was still produced then running with the flag, setting the --pixstack-limit to the image size (an upper limit) and showing that the image processed all the way through and the difference image produced was a reasonable difference image. It was run on g-band images from the night of 20180812 (id 165 and 166)

```
lscloop.py -n "2018eog" --normalize t -T 1m0 --temptel 1m0 --tempdate 20200720 --fixpix -s diff --difftype 1 -f g -e 20180812 -d 166 -F
```
This produced the above error as expected

```
lscloop.py -n "2018eog" --normalize t -T 1m0 --temptel 1m0 --tempdate 20200720 --fixpix -s diff --difftype 1 -f g -e 20180812 -d 166 -F --pixstack-limit 16000000
```
This processed successfully.