### PR TITLE
allowing psf stage to exit gracefully when it encounters an error

### DIFF
--- a/trunk/src/lsc/lscpsfdef.py
+++ b/trunk/src/lsc/lscpsfdef.py
@@ -514,5 +514,6 @@ def ecpsf(img, fwhm, threshold, psfstars, distance, interactive, psffun='gauss',
     except:
         result = 0
         fwhm = 0.0
+        aperture_correction = 0
         traceback.print_exc()
     return result, fwhm * scale, aperture_correction


### PR DESCRIPTION
# The Problem
Previously, when something went wrong in the PSF stage, the aperture correction would not be set and calibration would end with the error:
```
UnboundLocalError: local variable 'aperture_correction' referenced before assignment
```
which was misleading as this was a secondary error. This fix allows the code to correctly exit

# Testing
One way to produce an error in the psf stage is to run it with `--show` but not have ds9 open.
```
lscloop.py -n L107 -e 20210223 -f V -t elp -s psf --show -F
```
This should produce the above error in the current pipeline after an error about IRAF task display.
On this branch it will only produce the error about IRAF task display.

One minor annoyance is that it still asks you if the PSF is good, but then marks it as bad since the stage didn't complete - but I think this was already an issue with the pipeline before the aperture correction changes were made and is beyond the scope of this PR.