### PR TITLE
Experimental feature to calibrate to Pan-STARRS1 3π catalogs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,9 @@ RUN ln -s /usr/bin/sextractor /usr/bin/sex
 RUN pip install numpy>=1.12
 RUN pip install cryptography==2.4.1 astropy matplotlib==2.2.5 pyraf mysql-python scipy astroquery==v0.4 statsmodels==0.10 cython reproject
 
-RUN pip install sep==1.0.3 git+https://github.com/dguevel/PyZOGY.git && rm -rf ~/.cache/pip
+RUN pip install sep==1.0.3 git+https://github.com/dguevel/PyZOGY.git
+
+RUN pip install git+https://github.com/dfm/casjobs.git git+https://github.com/rlwastro/mastcasjobs.git && rm -rf ~/.cache/pip
 
 RUN wget http://ds9.si.edu/download/debian9/ds9.debian9.8.2.tar.gz \
         && tar -xzvf ds9.debian9.8.2.tar.gz -C /usr/local/bin \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       LCOSNDBPASS: "${LCOSNDBPASS:-supernova}"
       LCOSNDIR: "${LCOSNDIR:-/supernova}"
       DISPLAY: "${LCOSNDISPLAY:-host.docker.internal:0}"
+      CASJOBS_WSID: "$CASJOBS_WSID"
+      CASJOBS_PW: "$CASJOBS_PW"
     ports:
       - "4306:3306"
     links:

--- a/manual.md
+++ b/manual.md
@@ -21,6 +21,9 @@ LCOGTingest.py -n NAME -s YYYY-MM-DD -e YYYY-MM-DD -t EXPOSE -r reduced --public
 # Create gaia, apass, and sloan catalogs for new objects
 * run `comparecatalogs.py` to generate new catalogs
 * Note if you are trying to reduce U band, you need to generate a local catalog. See [Creating an Landolt Catalog](#Creating-a-Landolt-Catalog) for details.
+* As an experimental feature, you can now download Pan-STARRS1 3π catalogs instead of SDSS catalogs for calibrating _griz_ images.
+  To use this feature, you must make an account on [MAST CasJobs](http://mastweb.stsci.edu/ps1casjobs/) and store your WSID (available on the [Profile](http://mastweb.stsci.edu/ps1casjobs/ChangeDetails.aspx) tab) and password in the environment variables `CASJOBS_WSID` and `CASJOBS_PW`, respectively.
+  Then run `comparecatalogs.py -p`. Note that you will not be able to calibrate _u_-band images.
 
 # Cookbook
 ## Basic reduction

--- a/trunk/bin/comparecatalogs.py
+++ b/trunk/bin/comparecatalogs.py
@@ -23,6 +23,7 @@ for system in args.field:
     targets = lsc.mysqldef.query(['select id, ra0, dec0 from targets where ' + system + '_cat' + cond], lsc.conn)
     print len(targets), 'targets with no', system, 'catalog'
     print
+    source = 'panstarrs' if system == 'sloan' and args.panstarrs else system
     for target in targets:
         tid = str(target['id'])
         print 'Target ID', tid
@@ -30,7 +31,7 @@ for system in args.field:
         print ' aka '.join([n['name'] for n in names])
         filepath = os.path.join(default_catdir, system)
         for name in names: # see en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
-            filename = name['name'].translate(None, ' "*:<>?/|\\') + '_' + system + '.cat'
+            filename = name['name'].translate(None, ' "*:<>?/|\\') + '_' + source + '.cat'
             fullpath = os.path.join(filepath,  filename)
             fileexists = os.path.isfile(fullpath)
             if fileexists:


### PR DESCRIPTION
I added the `-p` flag to `comparecatalogs.py` to download Pan-STARRS1 3π catalogs instead of SDSS catalogs. These cover more of the sky and claim to have better photometry. There are a few difficulties with this feature, which is why I'm calling it experimental for now.

First of all, it introduces new dependencies ([`casjobs`](https://github.com/dfm/casjobs) and [`mastcasjobs`](https://github.com/rlwastro/mastcasjobs)), which are not available from PyPI but can be pip installed from GitHub. I added these to the Dockerfile.

Second, because it uses the CasJobs API, we need a way to provide a username and password. `mastcasjobs` accepts these as environment variables, which I explain in the manual, but it's not as simple as downloading catalogs from other services.

Third, the CasJobs API does not seem to be super reliable. I often get connection timeout errors.

With all those caveats, I think this will be a useful feature, and it shouldn't break any other pieces of the pipeline.

The reason I implemented this as a global flag to override SDSS, instead of only downloading PS1 catalogs when SDSS catalogs are not available, is that I think eventually we will want to make this the default. However if you think this is a bad idea, let me know.

**To test this feature:**
Running `comparecatalogs.py -p -F` will download PS1 catalogs for all targets that do not have SDSS catalogs. If you're not ready to do that yet, you could manually edit the database to set `sloan_cat=NULL` for one target and run `comparecatalogs.py -p` to download a catalog for just that one target. (Make sure that target is above -32° dec.)