### PR TITLE
ignore bad images when choosing color term filter

### DIFF
--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -20,6 +20,7 @@ def get_other_filters(filename):
                photlco AS p1, photlco AS p2,
                telescopes AS t1, telescopes AS t2
                WHERE p1.filename='{}'
+               AND p2.quality=127
                AND p1.dayobs=p2.dayobs
                AND p1.targetid=p2.targetid
                AND p1.telescopeid=t1.id


### PR DESCRIPTION
The pipeline chooses which color term to calculate (e.g., B with B-V) based on what other images were taken on the same night at the same site. However it currently uses all images, including ones that are marked as bad. This means it won't be able to calculate a magnitude at the end because it needs a magnitude from those bad images. This fixes the query to select only images with `quality=127` (good).