### PR TITLE
Updating normalization for --no_iraf PSF display

### DIFF
--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -1016,12 +1016,14 @@ def seepsf(psf_filename, saveto=None):
     :param saveto: filepath+filename of output file
     """
     psf_hdul = fits.open(psf_filename)
-    N = psf_hdul[0].header['PSFHEIGH'] / psf_hdul[0].header['NPSFSTAR']
     sigma_x = psf_hdul[0].header['PAR1']
     sigma_y = psf_hdul[0].header['PAR2']
     psfrad = psf_hdul[0].header['PSFRAD']
     NAXIS1 = psf_hdul[0].header['NAXIS1']
     NAXIS2 = psf_hdul[0].header['NAXIS2']
+    N = psf_hdul[0].header['PSFHEIGH'] / (sigma_x * sigma_y)
+    if sigma_x > 50 or sigma_y > 50:
+        print 'WARNING: PSF is very non-Gaussian, --no_iraf flag may display incorrectly'
 
     x = np.linspace(-psfrad, psfrad, num=NAXIS1)
     y = np.linspace(-psfrad, psfrad, num=NAXIS2)

--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -1026,6 +1026,7 @@ def seepsf(psf_filename, saveto=None):
     NAXIS2 = psf_hdul[0].header['NAXIS2']
     N = psf_hdul[0].header['PSFHEIGH'] / (PAR1 * PAR2)
 
+    # subsampling by factor of 2 in agreement with what iraf is doing
     x = np.linspace(-psfrad, psfrad, num=NAXIS1)
     y = np.linspace(-psfrad, psfrad, num=NAXIS2)
     X, Y = np.meshgrid(x, y)
@@ -1034,11 +1035,8 @@ def seepsf(psf_filename, saveto=None):
     analytic = N * np.exp(-(((X ** 2) / (sigma_x ** 2)) + ((Y ** 2) / (sigma_y ** 2))) / 2)
     residual = psf_hdul[0].data
     Z = analytic + residual
-    # our resampling is not quite what iraf does
-    # removing edge pixels/artifacts
-    X = X[3:-3, 3:-3]
-    Y = Y[3:-3, 3:-3]
-    Z = Z[3:-3, 3:-3]
+    # keeping just in psfrad
+    Z[residual == 0] = 0
     if saveto is not None:
         psf_hdul[0].data = Z
         psf_hdul.writeto(saveto, overwrite=True)


### PR DESCRIPTION
This mostly fixes the PSF display for very non-Gaussian PSFs, as brought up in [issue 95](https://github.com/LCOGT/lcogtsnpipe/issues/95). Tested with the extreme case there and also some more normal-looking PSFs (the first ones from 17eaw) to confirm it didn't break their display.

As stated in my response to the issue, this normalization is clearly not exactly correct, but I couldn't find where it was defined in the iraf code and this was the closest I could get. For very non-Gaussian PSFs it prints a warning to acknowledge that the display with `--no_iraf` might be inaccurate.