### PR TITLE
default to Gaia coordinates for local sequence calibration

### DIFF
--- a/trunk/bin/calibratemag.py
+++ b/trunk/bin/calibratemag.py
@@ -127,9 +127,12 @@ if __name__ == "__main__":
     if args.stage in ['abscat', 'local'] and args.catalog is not None:
         try:
             refcat = Table.read(args.catalog, format='ascii', fill_values=[('9999.000', '0')])
-            colnames = [row.split()[0] for row in refcat.meta['comments'] if len(row.split()) == 6]
-            for old, new in zip(refcat.colnames, colnames):
-                refcat.rename_column(old, new)
+            if 'source_id' in refcat.colnames:  # Gaia catalog
+                refcat.rename_column('source_id', 'id')
+            else:
+                colnames = [row.split()[0] for row in refcat.meta['comments'] if len(row.split()) == 6]
+                for old, new in zip(refcat.colnames, colnames):
+                    refcat.rename_column(old, new)
         except ascii.core.InconsistentTableError: # real Landolt catalogs are different
             refcat = Table.read(args.catalog, format='ascii', names=['id', 'ra', 'dec', 'U', 'B', 'V', 'R', 'I',
                                 'vary', 'Uerr', 'Berr', 'Verr', 'Rerr', 'Ierr', 'col13', 'col14', 'col15', 'col16', 'col17'],

--- a/trunk/bin/lscloop.py
+++ b/trunk/bin/lscloop.py
@@ -238,7 +238,7 @@ if __name__ == "__main__":   # main program
                 elif args.field:
                     catalogue = lsc.util.getcatalog(args.name, args.field)
                 else:
-                    catalogue = lsc.util.getcatalog(args.name, 'apass')
+                    catalogue = lsc.util.getcatalog(args.name, 'gaia')
                 if not args.field and args.filter and args.filter[0] in ['landolt', 'sloan', 'apass']:
                     field = args.filter[0]
                 else:


### PR DESCRIPTION
Currently the local sequence calibration uses the coordinates from the APASS catalog by default, since this is available for everything. However, now that we have the Gaia catalogs, we should default to that because they have more stars. You can still specify the catalog explicitly if you want to use APASS, so this doesn't lose any functionality.

To test, just run `-s local -i` for any supernova and see that the Gaia catalog filename is on the horizontal axis of the upper panel of the greatest figure ever.