### PR TITLE
Only ingesting standard frames for photometric standards

### DIFF
--- a/trunk/bin/ingestall.py
+++ b/trunk/bin/ingestall.py
@@ -39,7 +39,7 @@ except ValueError as e:
 
 frames = get_metadata(authtoken, start=start, end=end, OBSTYPE='EXPOSE', RLEVEL=91, public=False)       # all images where SNEx is a co-I
 for telid in ['2m0a', '1m0a', '0m4a', '0m4b', '0m4c']:
-    frames += get_metadata(authtoken, start=start, end=end, PROPID='Photometric standards', TELID=telid, RLEVEL=91)  # all photometric standards (except SQA)
+    frames += get_metadata(authtoken, start=start, end=end, PROPID='Photometric standards', OBSTYPE='STANDARD', TELID=telid, RLEVEL=91)  # all photometric standards (except SQA)
 frames += get_metadata(authtoken, start=start, end=end, INSTRUME='en06', RLEVEL=0, public=False)        # all FTN spectra SNEx is a co-I
 frames += get_metadata(authtoken, start=start, end=end, INSTRUME='en05', RLEVEL=0, public=False)        # all FTS spectra SNEx is a co-I
 frames += get_metadata(authtoken, start=start, end=end, INSTRUME='en12', RLEVEL=0, public=False)        # all FTS spectra SNEx is a co-I

--- a/trunk/bin/ingestall.py
+++ b/trunk/bin/ingestall.py
@@ -40,6 +40,7 @@ except ValueError as e:
 frames = get_metadata(authtoken, start=start, end=end, OBSTYPE='EXPOSE', RLEVEL=91, public=False)       # all images where SNEx is a co-I
 for telid in ['2m0a', '1m0a', '0m4a', '0m4b', '0m4c']:
     frames += get_metadata(authtoken, start=start, end=end, PROPID='Photometric standards', OBSTYPE='STANDARD', TELID=telid, RLEVEL=91)  # all photometric standards (except SQA)
+    frames += get_metadata(authtoken, start=start, end=end, PROPID='Photometric standards', OBSTYPE='EXPOSE', TELID=telid, RLEVEL=91)  # all photometric standards (except SQA)
 frames += get_metadata(authtoken, start=start, end=end, INSTRUME='en06', RLEVEL=0, public=False)        # all FTN spectra SNEx is a co-I
 frames += get_metadata(authtoken, start=start, end=end, INSTRUME='en05', RLEVEL=0, public=False)        # all FTS spectra SNEx is a co-I
 frames += get_metadata(authtoken, start=start, end=end, INSTRUME='en12', RLEVEL=0, public=False)        # all FTS spectra SNEx is a co-I


### PR DESCRIPTION
The pipeline was ingesting experimental frames that somehow got added as standard star observations to the archive. This PR will ignore those frames and only ingest frames which have `obstype='standard'` for photometric standards.