### PR TITLE
Fixed MuSCAT3 color terms

### DIFF
--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -300,6 +300,9 @@ def absphot(img,_field='',_catalogue='',_fix=True,rejection=2.,_interactive=Fals
     elif 'fa' in _instrume:
         colorefisso = {'uug': 0.0, 'ggr': 0.109, 'rri': 0.027, 'iri': 0.036, 'BBV': -0.024, 'VBV': -0.014,
                        'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
+    elif 'mc' in _instrume:
+        colorefisso = {'uug': 0.0, 'ggr': 0.0087, 'rri': 0.0166, 'iri': 0.0217, 'BBV': 0.0, 'VBV': 0.0,
+                   'UUB': 0.0, 'BUB': 0.0, 'VVR': 0.0, 'RVR': 0.0, 'RRI': 0.0, 'IRI': 0.0, 'ziz': 0.0152}
     elif _siteid == 'coj':
         colorefisso = {'uug': 0.0, 'ggr': 0.137, 'rri': -0.005, 'iri': 0.007, 'BBV': -0.025, 'VBV': 0.017, 'UUB':0.059,
                        'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
@@ -316,8 +319,11 @@ def absphot(img,_field='',_catalogue='',_fix=True,rejection=2.,_interactive=Fals
         colorefisso = {'uug': 0.0, 'ggr': 0.121, 'rri': -0.003, 'iri': 0.016, 'BBV': -0.032, 'VBV': -0.002, 'UUB':0.059,
                        'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
     else: # don't know where these came from
-        colorefisso = {'uug': 0.0, 'gug': 0.13, 'ggr': -0.02, 'rgr': 0.034, 'rri': 0.025, 'iri': 0.071, 'iiz': 0.110, 'ziz': -0.04,
-                       'UUB': 0.059, 'BUB': -0.095, 'BBV': 0.06, 'VBV': 0.03, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013}
+#        colorefisso = {'uug': 0.0, 'gug': 0.13, 'ggr': -0.02, 'rgr': 0.034, 'rri': 0.025, 'iri': 0.071, 'iiz': 0.110, 'ziz': -0.04,
+#                       'UUB': 0.059, 'BUB': -0.095, 'BBV': 0.06, 'VBV': 0.03, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013}
+
+        #I think we should raise an error if we cannot assign a meaningful color term.
+        raise Exception('No color term associated with the instrument.')
 
     if _cat and not redo:
         print 'already calibrated'

--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -300,7 +300,7 @@ def absphot(img,_field='',_catalogue='',_fix=True,rejection=2.,_interactive=Fals
     elif 'fa' in _instrume:
         colorefisso = {'uug': 0.0, 'ggr': 0.109, 'rri': 0.027, 'iri': 0.036, 'BBV': -0.024, 'VBV': -0.014,
                        'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
-    elif 'mc' in _instrume:
+    elif 'ep' in _instrume:
         colorefisso = {'uug': 0.0, 'ggr': 0.0087, 'rri': 0.0166, 'iri': 0.0217, 'BBV': 0.0, 'VBV': 0.0,
                    'UUB': 0.0, 'BUB': 0.0, 'VVR': 0.0, 'RVR': 0.0, 'RRI': 0.0, 'IRI': 0.0, 'ziz': 0.0152}
     elif _siteid == 'coj':


### PR DESCRIPTION
Fixed MuSCAT3 color terms. I used all our Muscat data from January 1st 2022 (arbitrary date), and calibrated them with PanSTARRS. These color terms could definitely be improved and done more thoroughly, but unless people start doing cosmology with Muscat data, these should be just fine for our everyday use. And most importantly, these are much closer to be correct than the random values the pipeline is currently using.

Moreover, the code now raises an Exception if a proper color term cannot be associated with the instrument. Before it just assigned random color terms. This way we can better control issues with new instruments in the future.