### PR TITLE
Bugfix/lscloop yshift fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.fits
-*.cat
 *.*~
 *.pyc
 .idea/

--- a/trunk/bin/lscloop.py
+++ b/trunk/bin/lscloop.py
@@ -191,7 +191,7 @@ if __name__ == "__main__":   # main program
                 lsc.myloopdef.run_fit(ll['filename'], args.RAS, args.DECS, args.xord, args.yord, args.bkg, args.size, args.recenter, args.ref,
                                       args.interactive, args.show, args.force, args.datamax,args.datamin,'photlco',args.RA0,args.DEC0)
             elif args.stage == 'wcs':
-                lsc.myloopdef.run_wcs(ll['filename'], args.interactive, args.force, args.xshift, args.xshift, args.catalogue,'photlco',args.mode)
+                lsc.myloopdef.run_wcs(ll['filename'], args.interactive, args.force, args.xshift, args.yshift, args.catalogue,'photlco',args.mode)
             elif args.stage == 'makestamp':
                 lsc.myloopdef.makestamp(ll['filename'], 'photlco', args.z1, args.z2, args.interactive, args.force, args.output)
             elif args.stage == 'apmag':


### PR DESCRIPTION
in `lscloop.py` there was a typo in the call to `run_wcs` where the `xshift` keyword was being passed in twice instead of passing in `xshift` and `yshift`. This PR fixes that.

To test run the `-s wcs` stage with` --xshift` and `--yshift` specified (and different) e.g.
```lscloop.py -n 2022xiw -e 20221030 -s wcs -b wcs -f r --id 46 --xshift 700 --yshift 0```

How to tell if it works:
Part of the output will be the line:
```lscastro.py /dark/hal/lcosn/data/2m0a/20221030/ogg2m001-ep02-20221030-0046-e91.fits -m  vizir --xshift 700 --yshift 0```

the `xshift` and `yshift` values you passed in should be printed here. Prior to this fix the `xshift` was repeated for both.
