### PR TITLE
Allow pipeline to process QHY600 CMOS detectors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p $iraf \
         && cd $iraf \
         && git checkout ba22d13 \
         && ./install < /dev/null \
-        && make -j4 $IRAFARCH \
+        && make $IRAFARCH \
         && make sysgen
 
 RUN apt-get --allow-releaseinfo-change update \

--- a/manual.md
+++ b/manual.md
@@ -90,7 +90,7 @@ Where:
 * ```-f FILTER``` run only on observations from one filter or set of filters (U,u,B,g,V,r,R,i,I,z,w,landolt, apass, sloan)
 * ```--id, -d``` run only on a specific image specified by a 3 digit number in the filename. For example you would use ```--id 046``` to run on the file elp1m008-fl05-20180302-0046-s91.
 * ```-T``` run only on observations from one telescope. Valid options: 1m0, 2m0, or 0m4. Note: because of the implementation, there is a bug/feature to `-T` that you can search for any substring in the filename
-* ```-I``` run only on observations from one instrument. Valid options: kb, fl, fs, sinistro, sbig, muscat, ep
+* ```-I``` run only on observations from one instrument. Valid options: kb, fl, fs, sinistro, sbig, muscat, ep, sq, qhy
 * ```-b STAGE``` run only on observations marked at bad at a given stage (where stage is quality, wcs, psf, psfmag, zcat, mag)
 * in many of the quality check stages the user is asked whether a file is good or bad and there are two options for bad, `b` and `n`. In general the `b` option should only be used for unusable images as it removes the observation completely from future processing and hides it. The only way to get this observation back is to run `-s checkquality -b quality`. If you answer `n` that stage of the pipeline will be reset for you to run again (as if the stage failed).
 

--- a/trunk/bin/lscloop.py
+++ b/trunk/bin/lscloop.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":   # main program
     parser = ArgumentParser(description=description)
     parser.add_argument("-e", "--epoch", help='args.epoch to reduce')
     parser.add_argument("-T", "--telescope", default='all')
-    parser.add_argument("-I", "--instrument", default='', help='kb, fl, fs, sinistro, sbig, ep, muscat, sq')
+    parser.add_argument("-I", "--instrument", default='', help='kb, fl, fs, sinistro, sbig, ep, muscat, sq, qhy')
     parser.add_argument("-n", "--name", default='', help='object name')
     parser.add_argument("-d", "--id", default='')
     parser.add_argument("-f", "--filter", default='', nargs='+',

--- a/trunk/bin/lscloop.py
+++ b/trunk/bin/lscloop.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":   # main program
     parser = ArgumentParser(description=description)
     parser.add_argument("-e", "--epoch", help='args.epoch to reduce')
     parser.add_argument("-T", "--telescope", default='all')
-    parser.add_argument("-I", "--instrument", default='', help='kb, fl, fs, sinistro, sbig, ep, muscat')
+    parser.add_argument("-I", "--instrument", default='', help='kb, fl, fs, sinistro, sbig, ep, muscat, sq')
     parser.add_argument("-n", "--name", default='', help='object name')
     parser.add_argument("-d", "--id", default='')
     parser.add_argument("-f", "--filter", default='', nargs='+',
@@ -245,7 +245,7 @@ if __name__ == "__main__":   # main program
                 if not args.name and not args.targetid:
                     raise Exception('you need to select one object: use option -n/--name')
                 if args.telescope=='all':
-                    raise Exception('you need to select one type of instrument -T [fs, fl, kb, ep]')
+                    raise Exception('you need to select one type of instrument -T [fs, fl, kb, ep, sq]')
                 
                 startdate = args.tempdate.split('-')[0]
                 enddate   = args.tempdate.split('-')[-1]
@@ -266,6 +266,8 @@ if __name__ == "__main__":   # main program
                         fake_temptel = 'sinistro'
                     elif args.telescope == 'ep':
                         fake_temptel = 'muscat'
+                    elif args.telescope == 'sq':
+                        fake_temptel = 'qhy'
                 elif args.temptel:
                     fake_temptel = args.temptel
                 else:

--- a/trunk/src/lsc/externaldata.py
+++ b/trunk/src/lsc/externaldata.py
@@ -566,6 +566,8 @@ def sloanimage(img,survey='sloan',frames=[], show=False, force=False):
       _telescope = 'sbig'
    elif 'ep' in _instrume:
        _telescope = 'muscat'
+   elif 'sq' in _instrume:
+       _telescope = 'qhy'
 
    print _ra, _dec, _band, _radius
    if survey == 'sloan':

--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -297,33 +297,14 @@ def absphot(img,_field='',_catalogue='',_fix=True,rejection=2.,_interactive=Fals
     elif 'fl' in _instrume:
         colorefisso = {'uug': 0.0, 'ggr': 0.109, 'rri': 0.027, 'iri': 0.036, 'BBV': -0.024, 'VBV': -0.014,
                        'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
-    elif 'sq' in _instrume:
-        # all color for sq  are wrong, we need to update the colors once we have the corect values
-        colorefisso = {'uug': 0.0, 'ggr': 0.0, 'rri': 0.0, 'iri': 0.0, 'BBV': -0.0, 'VBV': 0.0,
-                       'UUB': 0.0, 'BUB': 0.0, 'VVR': 0.0, 'RVR': 0.0, 'RRI': 0.0, 'IRI': 0.0, 'ziz': 0.00}
     elif 'fa' in _instrume:
         colorefisso = {'uug': 0.0, 'ggr': 0.109, 'rri': 0.027, 'iri': 0.036, 'BBV': -0.024, 'VBV': -0.014,
                        'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
     elif 'ep' in _instrume:
         colorefisso = {'uug': 0.0, 'ggr': 0.0087, 'rri': 0.0166, 'iri': 0.0217, 'BBV': 0.0, 'VBV': 0.0,
                    'UUB': 0.0, 'BUB': 0.0, 'VVR': 0.0, 'RVR': 0.0, 'RRI': 0.0, 'IRI': 0.0, 'ziz': 0.0152}
-    elif _siteid == 'coj':
-        colorefisso = {'uug': 0.0, 'ggr': 0.137, 'rri': -0.005, 'iri': 0.007, 'BBV': -0.025, 'VBV': 0.017, 'UUB':0.059,
-                       'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
-    elif _siteid == 'lsc':
-        colorefisso = {'uug': 0.0, 'ggr': 0.120, 'rri': -0.002, 'iri': 0.019, 'BBV': -0.035, 'VBV': 0.000, 'UUB':0.059,
-                       'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
-    elif _siteid == 'elp':
-        colorefisso = {'uug': 0.0, 'ggr': 0.114, 'rri': -0.004, 'iri': 0.024, 'BBV': -0.039, 'VBV': -0.005, 'UUB':0.059,
-                       'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
-    elif _siteid == 'cpt':
-        colorefisso = {'uug': 0.0, 'ggr': 0.112, 'rri': -0.001, 'iri': 0.013, 'BBV': -0.030, 'VBV': -0.019, 'UUB':0.059,
-                       'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
-    elif _siteid == 'tfn': # average of other SBIGs
-        colorefisso = {'uug': 0.0, 'ggr': 0.121, 'rri': -0.003, 'iri': 0.016, 'BBV': -0.032, 'VBV': -0.002, 'UUB':0.059,
-                       'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
     else: # don't attempt a color term if you don't know what the instrument is
-        print('No color terms exist for telescope/instrument set up. No color term applied')
+        print('No color terms exist for telescope/instrument set up. No color term applied, use --unfix to calculate a color term from the field stars in the image')
         colorefisso = {'uug': 0.0, 'gug': 0.0, 'ggr': 0.0, 'rgr': 0.0, 'rri': 0.0, 'iri': 0.0, 'iiz': 0.0, 'ziz': 0.0,
                        'UUB': 0.0, 'BUB': 0.0, 'BBV': 0.0, 'VBV': 0.0, 'VVR': 0.0, 'RVR': 0.0, 'RRI': 0.0, 'IRI': 0.0}
 

--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -297,6 +297,10 @@ def absphot(img,_field='',_catalogue='',_fix=True,rejection=2.,_interactive=Fals
     elif 'fl' in _instrume:
         colorefisso = {'uug': 0.0, 'ggr': 0.109, 'rri': 0.027, 'iri': 0.036, 'BBV': -0.024, 'VBV': -0.014,
                        'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}
+    elif 'sq' in _instrume:
+        # all color for sq  are wrong, we need to update the colors once we have the corect values
+        colorefisso = {'uug': 0.0, 'ggr': 0.0, 'rri': 0.0, 'iri': 0.0, 'BBV': -0.0, 'VBV': 0.0,
+                       'UUB': 0.0, 'BUB': 0.0, 'VVR': 0.0, 'RVR': 0.0, 'RRI': 0.0, 'IRI': 0.0, 'ziz': 0.00}
     elif 'fa' in _instrume:
         colorefisso = {'uug': 0.0, 'ggr': 0.109, 'rri': 0.027, 'iri': 0.036, 'BBV': -0.024, 'VBV': -0.014,
                        'UUB': 0.059, 'BUB': -0.095, 'VVR': -0.059, 'RVR': -0.028, 'RRI': -0.033, 'IRI': 0.013, 'ziz': -0.04}

--- a/trunk/src/lsc/lscastrodef.py
+++ b/trunk/src/lsc/lscastrodef.py
@@ -69,6 +69,28 @@ def wcsstart(img,CRPIX1='',CRPIX2=''):
         else: CRPIX2= 1000.+CRPIX2
         CDELT1=2
         CDELT2=2
+    elif 'sq' in _instrume:
+        angle=readkey3(hdr,'ROLLERDR')#posang)
+        theta=(angle*pi/180.)
+        pixscale=float(readkey3(hdr,'PIXSCALE'))
+        CDELT0=pixscale/3600.
+        CD1_1=CDELT0*cos(theta)
+        CD1_2=CDELT0*sin(theta)
+        CD2_1=CDELT0*sin(theta)
+        CD2_2=(-1)*CDELT0*cos(theta)
+        if 'SITEID' in hdr:
+            if hdr['SITEID'] in ['elp','tfn','ogg']:
+                CD1_1 = (-1) * CD1_1
+                CD2_2 = (-1) * CD2_2
+        if not CRPIX1:        
+            CRPIX1 = _xdimen/2
+        else: 
+            CRPIX1 = (_xdimen/2)+CRPIX1
+        if not CRPIX2:        
+            CRPIX2 = _ydimen/2
+        else: CRPIX2 = (_ydimen/2)+CRPIX2
+        CDELT1 = 2
+        CDELT2 = 2
     elif 'fl' in _instrume or 'fa' in _instrume or 'ep' in _instrume:
         angle=readkey3(hdr,'ROLLERDR')#posang)
         theta=(angle*pi/180.)
@@ -354,13 +376,13 @@ def lscastroloop(imglist,catalogue,_interactive,number1,number2,number3,_fitgeo,
             fwhmgess3=9999
             fwhmgessime=9999
             ellgess3=9999
-        if _instrume[:2] in ['kb', 'fl', 'fs', 'em', 'fa', 'ep']:
+        if _instrume[:2] in ['kb', 'fl', 'fs', 'em', 'fa', 'ep','sq']:
             mbkg3=median(bkg3)
             lsc.util.updateheader(img,0,{'MBKG':(mbkg3,'background level')})
         else:
             mbkg3=readkey3(hdr,'MBKG')
         if fwhmgess3:
-            if _instrume[:2] in ['kb', 'fl', 'fs', 'em', 'fa', 'ep']:
+            if _instrume[:2] in ['kb', 'fl', 'fs', 'em', 'fa', 'ep','sq']:
                 V=(math.pi/(4*math.log(2)))*(45000-float(mbkg3))*(float(fwhmgess3)**2)
             else:                     
                 V=(math.pi/(4*math.log(2)))*(32000-float(mbkg3))*(float(fwhmgess3)**2)
@@ -1361,6 +1383,8 @@ def run_astrometry(im, clobber=True,redo=False):
                     fwhm = half_total_flux_radius_to_fwhm(np.median(np.array(fw))) * 0.278
                 elif 'ep' in _instrume:
                     fwhm = half_total_flux_radius_to_fwhm(np.median(np.array(fw))) * 0.27
+                elif 'sq' in _instrume:
+                    fwhm = half_total_flux_radius_to_fwhm(np.median(np.array(fw))) * 0.734
                 else:
                     fwhm = 5
             else:

--- a/trunk/src/lsc/lscastrodef.py
+++ b/trunk/src/lsc/lscastrodef.py
@@ -356,7 +356,7 @@ def lscastroloop(imglist,catalogue,_interactive,number1,number2,number3,_fitgeo,
                 else:     fwhmgessime = 9999
             elif 'fl' in _instrume or 'fa' in _instrume:
                 fwhmgess3=half_total_flux_radius_to_fwhm(median(array(fwhm3))) * 0.389
-                if _imex:  fwhmgessime = median(array(ccc)) * 0.467
+                if _imex:  fwhmgessime = median(array(ccc)) * 0.389
                 else:     fwhmgessime = 9999
             elif 'fs' in _instrume:
                 fwhmgess3=half_total_flux_radius_to_fwhm(median(array(fwhm3))) * 0.30
@@ -369,6 +369,10 @@ def lscastroloop(imglist,catalogue,_interactive,number1,number2,number3,_fitgeo,
             elif 'ep' in _instrume:
                 fwhmgess3=half_total_flux_radius_to_fwhm(median(array(fwhm3))) * 0.27
                 if _imex:  fwhmgessime = median(array(ccc)) * 0.27
+                else:     fwhmgessime = 9999
+            elif 'sq' in _instrume:
+                fwhmgess3=half_total_flux_radius_to_fwhm(median(array(fwhm3))) * 0.734
+                if _imex:  fwhmgessime = median(array(ccc)) * 0.734
                 else:     fwhmgessime = 9999
             ellgess3=median(array(ell3))
 

--- a/trunk/src/lsc/lscastrodef.py
+++ b/trunk/src/lsc/lscastrodef.py
@@ -31,147 +31,37 @@ def vizq(_ra,_dec,catalogue,radius):
     return {'ra':_ra,'dec':_dec,'id':_name,'mag':_mag}
 
 def wcsstart(img,CRPIX1='',CRPIX2=''):
-    from numpy import pi, sin, cos 
+    from numpy import sin, cos, deg2rad
     import lsc
-    from lsc.util import updateheader,readhdr,readkey3
+    from lsc.util import readhdr,readkey3
     hdr=readhdr(img)
-    _instrume=readkey3(hdr,'instrume')
     _RA=readkey3(hdr,'RA')
     _DEC=readkey3(hdr,'DEC')
     _xdimen=readkey3(hdr,'NAXIS1')
     _ydimen=readkey3(hdr,'NAXIS2')
-    _CCDXBIN=readkey3(hdr,'CCDXBIN')
-    if _instrume in ['kb74','kb76']:
-        angle=readkey3(hdr,'ROLLERDR')#posang)
-        theta=(angle*pi/180.)
-        CDELT0=0.000129722   # 1.3042840792028E-4   8.43604528922325E-5  #6.6888889999999995e-05
-        CD1_1=(-1)*CDELT0*cos(theta)
-        CD2_2=(-1)*CDELT0*cos(theta)
-        CD1_2=abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        CD2_1=(-1)*abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        if not CRPIX1:        CRPIX1= readkey3(hdr,'ROTCENTX')
-        else: CRPIX1= 1000.+CRPIX1
-        if not CRPIX2:        CRPIX2= readkey3(hdr,'ROTCENTY')
-        else: CRPIX2= 1000.+CRPIX2
-        CDELT1=2
-        CDELT2=2
-    elif 'kb' in _instrume:
-        angle=readkey3(hdr,'ROLLERDR')#posang)
-        theta=(angle*pi/180.)
-        CDELT0=0.000129722   # 1.3042840792028E-4   8.43604528922325E-5  #6.6888889999999995e-05
-        CD1_1=(-1)*CDELT0*cos(theta)
-        CD2_2=(-1)*CDELT0*cos(theta)
-        CD1_2=abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        CD2_1=(-1)*abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        if not CRPIX1:        CRPIX1= 1000.
-        else: CRPIX1= 1000.+CRPIX1
-        if not CRPIX2:        CRPIX2= 1000.
-        else: CRPIX2= 1000.+CRPIX2
-        CDELT1=2
-        CDELT2=2
-    elif 'sq' in _instrume:
-        angle=readkey3(hdr,'ROLLERDR')#posang)
-        theta=(angle*pi/180.)
-        pixscale=float(readkey3(hdr,'PIXSCALE'))
-        CDELT0=pixscale/3600.
-        CD1_1=CDELT0*cos(theta)
-        CD1_2=CDELT0*sin(theta)
-        CD2_1=CDELT0*sin(theta)
-        CD2_2=(-1)*CDELT0*cos(theta)
-        if 'SITEID' in hdr:
-            if hdr['SITEID'] in ['elp','tfn','ogg']:
-                CD1_1 = (-1) * CD1_1
-                CD2_2 = (-1) * CD2_2
-        if not CRPIX1:        
-            CRPIX1 = _xdimen/2
-        else: 
-            CRPIX1 = (_xdimen/2)+CRPIX1
-        if not CRPIX2:        
-            CRPIX2 = _ydimen/2
-        else: CRPIX2 = (_ydimen/2)+CRPIX2
-        CDELT1 = 2
-        CDELT2 = 2
-    elif 'fl' in _instrume or 'fa' in _instrume or 'ep' in _instrume:
-        angle=readkey3(hdr,'ROLLERDR')#posang)
-        theta=(angle*pi/180.)
-        pixscale=float(readkey3(hdr,'PIXSCALE'))
-        CDELT0=pixscale/3600.
-        CD1_1=CDELT0*cos(theta)
-        CD1_2=CDELT0*sin(theta)
-        CD2_1=CDELT0*sin(theta)
-        CD2_2=(-1)*CDELT0*cos(theta)
-        if 'SITEID' in hdr:
-            if hdr['SITEID'] in ['elp']:
-                CD1_1 = (-1) * CD1_1
-                CD2_2 = (-1) * CD2_2
-#        CD1_1=(-1)*CDELT0*cos(theta)
-#        CD2_2=(-1)*CDELT0*cos(theta)
-#        CD1_2=abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-#        CD2_1=(-1)*abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        if not CRPIX1:        
-            CRPIX1 = _xdimen/2
-        else: 
-            CRPIX1 = (_xdimen/2)+CRPIX1
-        if not CRPIX2:        
-            CRPIX2 = _ydimen/2
-        else: CRPIX2 = (_ydimen/2)+CRPIX2
-        CDELT1 = 2
-        CDELT2 = 2
-    elif _instrume in ['fs03']:
-        angle=readkey3(hdr,'ROTSKYPA')#posang)
-        theta=(angle*pi/180.)
- #       pixscale=0.30*_CCDXBIN
- #       CDELT0=pixscale/3600.
-        CDELT0=0.000083705976   #8.43604528922325E-5  #6.6888889999999995e-05
-        CD1_1=(-1)*CDELT0*cos(theta)
-        CD2_2=CDELT0*cos(theta)
-        CD1_2=abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        CD2_1=abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        if not CRPIX1:        CRPIX1= 1024.
-        else: CRPIX1= 1024.+CRPIX1
-        if not CRPIX2:        CRPIX2= 1024.
-        else: CRPIX2= 1024.+CRPIX2
-        CDELT1=0.000083705976*(-1)
-        CDELT2=0.000083705976
-    elif 'fs' in _instrume:
-        angle=readkey3(hdr,'ROTSKYPA')#posang)
-        theta=(angle*pi/180.)
- #       pixscale=0.30*_CCDXBIN
- #       CDELT0=pixscale/3600.
-        CDELT0=0.000083568667  # 8.43604528922325E-5  #6.6888889999999995e-05
-        CD1_1=(-1)*CDELT0*cos(theta)
-        CD2_2=CDELT0*cos(theta)
-        CD1_2=abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        CD2_1=abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        if not CRPIX1:        CRPIX1= 1024.
-        else: CRPIX1= 1024.+CRPIX1
-        if not CRPIX2:        CRPIX2= 1024.
-        else: CRPIX2= 1024.+CRPIX2
-        CDELT1=0.000083568694*(-1)
-        CDELT2=0.000083568694
-    elif 'em' in _instrume.lower():
-        theta=(angle*pi/180.)
-        CDELT0=7.63077724258886e-05 #7.7361111111111123e-05 
-        CD1_1=(-1)*CDELT0*cos(theta)
-        CD2_2=CDELT0*cos(theta)
-        CD1_2=abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        CD2_1=abs(CDELT0)*(abs(CDELT0)/CDELT0)*sin(theta)
-        if not CRPIX1:        CRPIX1= readkey3(hdr,'ROTCENTX')
-        if not CRPIX2:        CRPIX2= readkey3(hdr,'ROTCENTY')-100
-        CDELT1=2
-        CDELT2=2
-    else:  print '\n### ERROR: instument not found !!!'
+    binning=readkey3(hdr,'CCDSUM').split()
+    pixscale = float(readkey3(hdr,'PIXSCALE'))
+    position_angle = deg2rad(readkey3(hdr,'ROLLERDR'))
+    CDELT1 = float(binning[0]) * pixscale
+    CDELT2 = float(binning[1]) * pixscale
+    CRVAL1 = hdr.get('CRVAL1', _RA)
+    CRVAL2 = hdr.get('CRVAL2', _DEC)
+    CRPIX1 = hdr.get('CRPIX1', _xdimen // 2)
+    CRPIX2 = hdr.get('CRPIX2', _ydimen // 2)
+    if CRPIX1:
+        CRPIX1 += float(CRPIX1)
+    if CRPIX2:
+        CRPIX2 += float(CRPIX2)
+    CD1_1 = hdr.get('CD1_1', -CDELT1 * cos(position_angle))
+    CD1_2 = hdr.get('CD1_2', CDELT2 * sin(position_angle))
+    CD2_1 = hdr.get('CD2_1', -CDELT1 * sin(position_angle))
+    CD2_2 = hdr.get('CD2_2', CDELT2 * cos(position_angle))
 
-    CTYPE1  = 'RA---TAN'  
-    CTYPE2  = 'DEC--TAN' 
-    CRVAL1=_RA
-    CRVAL2=_DEC
-    WCSDIM  =                   2  
-    LTM1_1  =                   1. 
-    LTM2_2  =                   1.
-    WAT0_001= 'system=image'
-    WAT1_001= 'wtype=tan axtype=ra'
-    WAT2_001= 'wtype=tan axtype=dec'
+    CTYPE1 = 'RA---TAN'  
+    CTYPE2 = 'DEC--TAN' 
+    CRVAL1 = _RA
+    CRVAL2 = _DEC
+    WCSDIM = 2  
     lsc.util.updateheader(img,0,{'CTYPE1':CTYPE1, 'CTYPE2':CTYPE2, 'CRVAL1':CRVAL1, 'CRVAL2':CRVAL2,
                 'CRPIX1':CRPIX1, 'CRPIX2':CRPIX2, 'CDELT1':CDELT1, 'CDELT2':CDELT2,
                 'CD1_1':CD1_1, 'CD2_2':CD2_2, 'CD1_2':CD1_2, 'CD2_1':CD2_1,

--- a/trunk/src/lsc/mysqldef.py
+++ b/trunk/src/lsc/mysqldef.py
@@ -190,7 +190,7 @@ def guess_instrument_type(name):
     elif prefix == 'ep':
         insttype = 'MUSCAT'
     elif prefix == 'sq':
-        insttype = 'qhy'
+        insttype = 'QHY'
     else:
         insttype = None
     return insttype

--- a/trunk/src/lsc/mysqldef.py
+++ b/trunk/src/lsc/mysqldef.py
@@ -189,6 +189,8 @@ def guess_instrument_type(name):
         insttype = 'Spectral'
     elif prefix == 'ep':
         insttype = 'MUSCAT'
+    elif prefix == 'sq':
+        insttype = 'qhy'
     else:
         insttype = None
     return insttype

--- a/trunk/src/lsc/util.py
+++ b/trunk/src/lsc/util.py
@@ -137,7 +137,7 @@ def readkey3(hdr,keyword):
        _instrume=hdr.get('INSTRUME').lower()
     except: 
        _instrume='none'
-    if ('kb' in _instrume) or ('sq' in instrume): # SBIG or QHY
+    if ('kb' in _instrume) or ('sq' in _instrume): # SBIG or QHY
         useful_keys = {'object'    : 'OBJECT',\
                            'date-obs'  : 'DATE-OBS',\
                            'ut'        : 'DATE-OBS',\

--- a/trunk/src/lsc/util.py
+++ b/trunk/src/lsc/util.py
@@ -161,6 +161,31 @@ def readkey3(hdr,keyword):
                            'type'      : 'OBSTYPE',\
                            'propid'      : 'PROPID',\
                            'userid'      : 'USERID',\
+                           'telescop'  : 'TELESCOP'}
+    elif 'sq' in _instrume: # CMOS
+        useful_keys = {'object'    : 'OBJECT',\
+                           'date-obs'  : 'DATE-OBS',\
+                           'ut'        : 'DATE-OBS',\
+                           'date-night': 'DAY-OBS',\
+                           'RA'        : 'RA',\
+                           'DEC'       : 'DEC',\
+                           'CAT-RA'    : 'CAT-RA',\
+                           'CAT-DEC'   : 'CAT-DEC',\
+                           'datamin'   :  -100.0,\
+                           'datamax'   : 'SATURATE',\
+                           'observer'  : 'OBSERVER',\
+                           'exptime'   : 'EXPTIME',\
+                           'wcserr'    : 'WCSERR',\
+                           'instrume'  : 'INSTRUME',\
+                           'JD'        : 'MJD-OBS',\
+                           'mjd'        : 'MJD-OBS',\
+                           'filter'    : 'FILTER',\
+                           'gain'      : 'GAIN',\
+                           'ron'       : 'RDNOISE',\
+                           'airmass'   : 'AIRMASS',\
+                           'type'      : 'OBSTYPE',\
+                           'propid'      : 'PROPID',\
+                           'userid'      : 'USERID',\
                            'telescop'  : 'TELESCOP'} 
     elif 'fl' in _instrume or 'fa' in _instrume: # sinistro
         useful_keys = {'object'    : 'OBJECT',\

--- a/trunk/src/lsc/util.py
+++ b/trunk/src/lsc/util.py
@@ -137,7 +137,7 @@ def readkey3(hdr,keyword):
        _instrume=hdr.get('INSTRUME').lower()
     except: 
        _instrume='none'
-    if 'kb' in _instrume: # SBIG
+    if ('kb' in _instrume) or ('sq' in instrume): # SBIG or QHY
         useful_keys = {'object'    : 'OBJECT',\
                            'date-obs'  : 'DATE-OBS',\
                            'ut'        : 'DATE-OBS',\
@@ -162,31 +162,6 @@ def readkey3(hdr,keyword):
                            'propid'      : 'PROPID',\
                            'userid'      : 'USERID',\
                            'telescop'  : 'TELESCOP'}
-    elif 'sq' in _instrume: # CMOS
-        useful_keys = {'object'    : 'OBJECT',\
-                           'date-obs'  : 'DATE-OBS',\
-                           'ut'        : 'DATE-OBS',\
-                           'date-night': 'DAY-OBS',\
-                           'RA'        : 'RA',\
-                           'DEC'       : 'DEC',\
-                           'CAT-RA'    : 'CAT-RA',\
-                           'CAT-DEC'   : 'CAT-DEC',\
-                           'datamin'   :  -100.0,\
-                           'datamax'   : 'SATURATE',\
-                           'observer'  : 'OBSERVER',\
-                           'exptime'   : 'EXPTIME',\
-                           'wcserr'    : 'WCSERR',\
-                           'instrume'  : 'INSTRUME',\
-                           'JD'        : 'MJD-OBS',\
-                           'mjd'        : 'MJD-OBS',\
-                           'filter'    : 'FILTER',\
-                           'gain'      : 'GAIN',\
-                           'ron'       : 'RDNOISE',\
-                           'airmass'   : 'AIRMASS',\
-                           'type'      : 'OBSTYPE',\
-                           'propid'      : 'PROPID',\
-                           'userid'      : 'USERID',\
-                           'telescop'  : 'TELESCOP'} 
     elif 'fl' in _instrume or 'fa' in _instrume: # sinistro
         useful_keys = {'object'    : 'OBJECT',\
                            'date-obs'  : 'DATE-OBS',\


### PR DESCRIPTION
This PR was modeled off of PR #80 which implemented MuSCAT

Other changes:
- This also slightly changes the way the color correction is used when no instrument is found. Previously there were site colors defined. I have removed them and now it defaults to 0 color correction and prints a warning to the screen that the color correction is 0 and suggests using the --unfix option to calculate a color correction.
- Fixed a bug in the wcs calculation (only used when BANZAI fails) for the fwhmgess3 for the sinistro telescopes

Testing:
I tested this on the 2024-02-06 data from proposal LCOEPO2014B-010 of SN 2024bch

I ran the following commands:
```
lscloop.py -n 2024bch -e 20240206 -T sq -s psf
lscloop.py -n 2024bch -e 20240206 -T sq -s psfmag
lscloop.py -n 2024bch -e 20240206 -T sq -s zcat #This results in no color correction applied
lscloop.py -n 2024bch -e 20240206 -T sq -s zcat --unfix -F #this calculates the color correction
lscloop.py -n 2024bch -e 20240206 -T sq -s mag
```

I compared the final photometry for a few different epochs and ii was all pretty close to the 1m reduction taken at about the same time.

To test the wcs stage:
`lscloop.py -n 2024bch -e 20240206 -T sq --id 184 -s wcs`

I then loaded the BANZAI and wcs stage image into DS9 and matched WCS - they aligned pretty closely

I noticed a weird bug here that the WCS gets updated but the other database terms aren't reset because the filename contains an extra .fits. But this isn't a bug introduced by this PR and it doesn't break anything, so I'm not going to fix it right now. I've filed this as Issue 131.

Note that this PR does not check difference imaging capabilities
