### PR TITLE
Correcting for a missing gain factor in the noise image creation

### DIFF
--- a/trunk/bin/lscdiff.py
+++ b/trunk/bin/lscdiff.py
@@ -25,7 +25,8 @@ def create_variance_image(_data, _gain, _ron):
     #pssl = previously subtracted sky level
     pssl = _gain*std**2 - _ron**2/_gain - median
 
-    return _data/_gain + pssl/_gain + _ron**2/_gain**2, pssl #variance in ADUs^2
+    #return variance in ADUs^2
+    return _data/_gain + pssl/_gain + _ron**2/_gain**2, pssl 
 
 
 def crossmatchtwofiles(img1, img2, radius=3):

--- a/trunk/bin/lscdiff.py
+++ b/trunk/bin/lscdiff.py
@@ -25,7 +25,7 @@ def create_variance_image(_data, _gain, _ron):
     #pssl = previously subtracted sky level
     pssl = _gain*std**2 - _ron**2/_gain - median
 
-    return _data/_gain + pssl/_gain + _ron**2/_gain**2 #variance in ADUs^2
+    return _data/_gain + pssl/_gain + _ron**2/_gain**2, pssl #variance in ADUs^2
 
 
 def crossmatchtwofiles(img1, img2, radius=3):
@@ -196,7 +196,7 @@ if __name__ == "__main__":
                         targnoise = 'targnoise.fits'
 
                         # create the noise images
-                        noiseimg = create_variance_image(data_targ, gain_targ, rn_targ)
+                        noiseimg, pssl_targ = create_variance_image(data_targ, gain_targ, rn_targ)
 
                         targmask_data = fits.getdata(_dir + targmask0)
                         if noiseimg.size == targmask_data.size:


### PR DESCRIPTION
When the noise image was created, a few missing gain factor were missing.
Since the noise image is created at least in two instances, I created a separate function. I also added some comments to make it more readable.

The gain for Sinistro should be 1, so even with this bug, previous LCO-LCO subtractions should not have been affected. However subtraction using other surveys might have.