### PR TITLE
changing source_id to SOURCE_ID to match change in Gaia catalog output

### DIFF
--- a/trunk/bin/calibratemag.py
+++ b/trunk/bin/calibratemag.py
@@ -130,8 +130,8 @@ if __name__ == "__main__":
     if args.stage in ['abscat', 'local'] and args.catalog is not None:
         try:
             refcat = Table.read(args.catalog, format='ascii', fill_values=[('9999.000', '0')])
-            if 'source_id' in refcat.colnames:  # Gaia catalog
-                refcat.rename_column('source_id', 'id')
+            if 'SOURCE_ID' in refcat.colnames:  # Gaia catalog
+                refcat.rename_column('SOURCE_ID', 'id')
             else:
                 colnames = [row.split()[0] for row in refcat.meta['comments'] if len(row.split()) == 6]
                 for old, new in zip(refcat.colnames, colnames):

--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -1258,6 +1258,6 @@ def gaia2file(ra, dec, size=26., mag_limit=18., output='gaia.cat'):
     response['dec'].format = '%16.12f'
     response['phot_g_mean_mag'].format = '%.2f'
 
-    gaia_cat = response['ra', 'dec', 'source_id', 'phot_g_mean_mag']
+    gaia_cat = response['ra', 'dec', 'SOURCE_ID', 'phot_g_mean_mag']
     gaia_cat.write(output, format='ascii.commented_header',
             delimiter=' ', overwrite=True)


### PR DESCRIPTION
I tested this by running `compare_catalogs.py` on dark and it properly downloaded Gaia catalogs.

I then ran the following to fully calibrate the data:
```
lscloop.py -n 'WISEAJ075041.08-302027.1' -s psf
lscloop.py -n 'WISEAJ075041.08-302027.1' -s psfmag
lscloop.py -n 'WISEAJ075041.08-302027.1' -s zcat
lscloop.py -n 'WISEAJ075041.08-302027.1' -s mag
```
This resulted in calibrated r and I band filter - z band doesn't have a zero point from the apass catalog - so this will not get an apparent magnitude