### PR TITLE
Removed new lines in the sql query to sdss which was crashing intermittently

### DIFF
--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -1108,9 +1108,10 @@ def zeronew(ZZ,maxiter=10,nn=5,verbose=False,show=False):
 #######################################################################
 def sloan2file(ra, dec, radius=10., mag1=13., mag2=20., output='sloan.cat'):
     '''download an SDSS catalog'''
-    t = SDSS.query_sql('''select P.ra, P.dec, P.objID, P.u, P.err_u, P.g, P.err_g, P.r, P.err_r, P.i, P.err_i, P.z, P.err_z
-                          from PhotoPrimary as P, dbo.fGetNearbyObjEq({}, {}, {}) as N
-                          where P.objID=N.objID and P.type=6 and P.r >= {} and P.r <= {}'''.format(ra, dec, radius, mag1, mag2))
+    sql_command = "select P.ra, P.dec, P.objID, P.u, P.err_u, P.g, P.err_g, P.r, P.err_r, P.i, P.err_i, P.z, P.err_z " + \
+                  "from PhotoPrimary as P, dbo.fGetNearbyObjEq({}, {}, {}) as N " + \
+                  "where P.objID=N.objID and P.type=6 and P.r >= {} and P.r <= {};"
+    t = SDSS.query_sql(sql_command.format(ra, dec, radius, mag1, mag2))
     if t is not None:
         t['ra'].format ='%16.12f'
         t['dec'].format = '%16.13f'


### PR DESCRIPTION
There has been a strange crash in comparecatalogs.py. This was crashing in the SQL query to sdss. When I checked the response from the SDSS server it said "Uncaught error occurred" without more information. The bug was intermittent. If I used the exact parameters from AT 2024zkl, it would crash. If I changed the radius from 20.0 to 20 or 15.0 everything worked. Removing the newlines in the SQL query seemed to fix it in as much that it ran for 24zkl. Beyond that I haven't been able to reproduce the bug so its hard to validate it more than that. 