### PR TITLE
add API token option to LCOGTingest.py

### DIFF
--- a/trunk/bin/LCOGTingest.py
+++ b/trunk/bin/LCOGTingest.py
@@ -278,6 +278,8 @@ if __name__ == "__main__":
 
     if args.username and args.password:
         authtoken = authenticate(args.username, args.password)
+    elif os.getenv('LCO_API_KEY'):
+        authtoken = {'Authorization': 'Token ' + os.environ['LCO_API_KEY']}
     else:
         authtoken = {}
 


### PR DESCRIPTION
This allows people with an API key to use that to access the archive instead of entering the username and password on the command line. For example:
```
LCOGTingest.py -l 1 -s 2025-02-13 -P KEY2023B-002 -r reduced
```
should return no frames, whereas
```
export LCO_API_KEY=sdf087asdf987asdf0786987
LCOGTingest.py -l 1 -s 2025-02-13 -P KEY2023B-002 -r reduced
```
should return one frame.

You could also set this `LCO_API_KEY` environment variable in your `.bashrc` or similar.

If you have a portal account, you can get (or replace) your API key from https://observe.lco.global/accounts/profile.