### PR TITLE
Update the LCOGTingest.py and ingestall.py to include Banzai floyds 

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -125,8 +125,12 @@ Where:
 * **How to fix this step if the image looks ok but the wcs failed**
     * rerun lscloop.py with the step ```-s wcs -b wcs``` to run only on those files for which the wcs failed
     * try running with the --catalog option
-    * try using ```--mode astrometry``` to use astrometry.net to solve the WCS
+    * try using ```--mode astrometry``` to use astrometry.net to solve the WCS. Note this only works if astrometry.net has been installed. astrometry.net is not installed in the docker version of the pipeline
     * try using ```--xshift 1 --yshift 1``` to start the solution from a slightly different location
+    * If you get the error: "ERROR: catalog empty 2MASS" this means `lscastrodef.querycatalogue` is failing. It could mean one of two things:
+        - the vizier query in `lscastrodef.vizq` is timing out. If this is the issue, you will either have to wait or manually solve the WCS with astrometry.net and then update the WCS column in the photlco table
+        - the `CRPIX` value in the header of the file you downloaded from SNEx was corrupt. You can check this by looking at the `CRPIX1` and `CRPIX2` header keywords. These should not be very large numbers (like 1E42). If the file is corrupt, you can download it directly from the LCO archive or if you don't have permission, request in the pipeline channel that someone download the files for you (or for large downloads, give you the proper archive permissions).
+        - For either case, you should also check that the apass, sloan, and gaia catalogs you downloaded for the target are not empty
 
 ### Generate a PSF model
 * **Call**: ```-s psf```

--- a/trunk/bin/calibratemag.py
+++ b/trunk/bin/calibratemag.py
@@ -130,8 +130,8 @@ if __name__ == "__main__":
     if args.stage in ['abscat', 'local'] and args.catalog is not None:
         try:
             refcat = Table.read(args.catalog, format='ascii', fill_values=[('9999.000', '0')])
-            if 'SOURCE_ID' in refcat.colnames:  # Gaia catalog
-                refcat.rename_column('SOURCE_ID', 'id')
+            if 'source_id' in refcat.colnames:  # Gaia catalog
+                refcat.rename_column('source_id', 'id')
             else:
                 colnames = [row.split()[0] for row in refcat.meta['comments'] if len(row.split()) == 6]
                 for old, new in zip(refcat.colnames, colnames):

--- a/trunk/src/lsc/lscabsphotdef.py
+++ b/trunk/src/lsc/lscabsphotdef.py
@@ -1243,6 +1243,6 @@ def gaia2file(ra, dec, size=26., mag_limit=18., output='gaia.cat'):
     response['dec'].format = '%16.12f'
     response['phot_g_mean_mag'].format = '%.2f'
 
-    gaia_cat = response['ra', 'dec', 'SOURCE_ID', 'phot_g_mean_mag']
+    gaia_cat = response['ra', 'dec', 'source_id', 'phot_g_mean_mag']
     gaia_cat.write(output, format='ascii.commented_header',
             delimiter=' ', overwrite=True)


### PR DESCRIPTION
Made changes to `LCOGTingest.py` and `ingestall.py` to include automatic ingestion of Banzai floyds 1d spectrum files from the archive. The changes include adding frames with basename including `e91-1d` on top of the e00 files needed for IRAF reduction. The `e91-1d` Banzai files are also ingested into 2 tables: `spec` and `speclcoraw`. The e00 files for IRAF reduction are only ingested into `speclcoraw`. `speclocraw` is where the snex observing script checks for a successful spectrum observation, so this is to avoid observations being triggered unnecessarily. In the future when the IRAF floyds pipeline is retired, the e00 files will no longer need to be ingested or be ingested differently into `speclcoraw`.

The Banzai files are additionally ingested into the `spec` table to bypass the `archivingspec.py` function that will move the IRAF reduced spectra into the `spec` table at the end of reduction. Future implementation of Banzai reduction and LCO archival version history tracking with the floyds inbox page would be implemented here.

This can be tested as running `ingestall.py [date]-[date]` with a given date range. The Banzai spectra should be visible in the database in the `spec` and `speclcoraw` tables.

This commit has not been tested in its entirety. It has been tested locally with the photometry and standards ingested commented out. I do not anticipate errors arising from these lines in the current state.